### PR TITLE
test(compose): add E2E coverage for AppNav, Drawer, and Settings…

### DIFF
--- a/app/src/androidTest/java/com/android/sample/home/DrawerContentTest.kt
+++ b/app/src/androidTest/java/com/android/sample/home/DrawerContentTest.kt
@@ -1,0 +1,52 @@
+package com.android.sample.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DrawerContentTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun shows_sections_and_triggers_callbacks() {
+    var toggled = false
+    var settingsClicked = false
+    var signOutClicked = false
+
+    composeRule.setContent {
+      MaterialTheme {
+        DrawerContent(
+            onToggleSystem = { toggled = true },
+            onSettingsClick = { settingsClicked = true },
+            onSignOut = { signOutClicked = true })
+      }
+    }
+
+    // Sections
+    composeRule.onNodeWithText("CONNECTED SYSTEMS").assertIsDisplayed()
+    composeRule.onNodeWithText("RECENT ACTIONS").assertIsDisplayed()
+    composeRule.onNodeWithText("Settings").assertIsDisplayed()
+
+    // Click any system label to trigger toggle
+    composeRule.onNodeWithText("Moodle").performClick()
+    assertTrue(toggled)
+
+    // Click Settings
+    composeRule.onNodeWithText("Settings").performClick()
+    assertTrue(settingsClicked)
+
+    // Click Sign Out
+    composeRule.onNodeWithText("Sign Out").performClick()
+    assertTrue(signOutClicked)
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/navigation/AppNavE2ETest.kt
+++ b/app/src/androidTest/java/com/android/sample/navigation/AppNavE2ETest.kt
@@ -1,0 +1,70 @@
+package com.android.sample.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.authentification.AuthTags
+import com.android.sample.home.HomeTags
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppNavE2ETest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun signIn_to_home_to_settings_back_then_signOut_returns_to_signIn() {
+    composeRule.setContent {
+      MaterialTheme { AppNav(startOnSignedIn = false, activity = composeRule.activity) }
+    }
+
+    // Sign-In screen visible
+    composeRule.onNodeWithTag(AuthTags.Root).assertIsDisplayed()
+
+    // Switch edu path: simulated async success (1200 ms) via ViewModel
+    composeRule.onNodeWithTag(AuthTags.BtnSwitchEdu).performClick()
+
+    composeRule.waitUntil(timeoutMillis = 6_000) {
+      composeRule.onAllNodesWithTag(HomeTags.Root).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Home visible
+    composeRule.onNodeWithTag(HomeTags.Root).assertIsDisplayed()
+    composeRule.onNodeWithTag(HomeTags.MenuBtn).assertIsDisplayed()
+    composeRule.onNodeWithTag(HomeTags.TopRightBtn).assertIsDisplayed()
+
+    // Open drawer and navigate to Settings
+    composeRule.onNodeWithTag(HomeTags.MenuBtn).performClick()
+    composeRule.onNodeWithText("Settings").performClick()
+
+    // Settings header text
+    composeRule.onNodeWithText("Settings").assertIsDisplayed()
+
+    // Back to Home (drawer should reopen via HomeWithDrawer route)
+    // Back icon uses contentDescription
+    composeRule.onNode(hasContentDescription("Back")).performClick()
+
+    composeRule.waitUntil(timeoutMillis = 3_000) {
+      composeRule.onAllNodesWithTag(HomeTags.Root).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Open drawer and sign out
+    composeRule.onNodeWithTag(HomeTags.MenuBtn).performClick()
+    composeRule.onNodeWithText("Sign Out").performClick()
+
+    // Back to Sign-In
+    composeRule.waitUntil(timeoutMillis = 3_000) {
+      composeRule.onAllNodesWithTag(AuthTags.Root).fetchSemanticsNodes().isNotEmpty()
+    }
+    composeRule.onNodeWithTag(AuthTags.Root).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/navigation/MicrosoftFlowE2ETest.kt
+++ b/app/src/androidTest/java/com/android/sample/navigation/MicrosoftFlowE2ETest.kt
@@ -1,0 +1,49 @@
+package com.android.sample.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.sample.authentification.AuthTags
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MicrosoftFlowE2ETest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Ignore("Requires Firebase/Provider UI; skip in default connected test run")
+  @Test
+  fun microsoft_login_shows_loading_then_returns_to_signin_buttons_enabled_on_error() {
+    composeRule.setContent {
+      MaterialTheme { AppNav(startOnSignedIn = false, activity = composeRule.activity) }
+    }
+
+    // Click Microsoft login
+    composeRule.onNodeWithTag(AuthTags.BtnMicrosoft).performClick()
+
+    // Loading indicator for Microsoft appears, and buttons disabled
+    composeRule.onNodeWithTag(AuthTags.MsProgress).assertIsDisplayed()
+    composeRule.onNodeWithTag(AuthTags.BtnMicrosoft).assertIsNotEnabled()
+
+    // We expect that since real Microsoft flow isn't completed, we remain on SignIn and eventually
+    // buttons re-enable.
+    composeRule.waitUntil(timeoutMillis = 5_000) {
+      // We simply wait until the loading indicator disappears
+      composeRule.onAllNodesWithTag(AuthTags.MsProgress).fetchSemanticsNodes().isEmpty()
+    }
+
+    composeRule.onNodeWithTag(AuthTags.BtnMicrosoft).assertIsEnabled()
+    composeRule.onNodeWithTag(AuthTags.BtnSwitchEdu).assertIsEnabled()
+    composeRule.onNodeWithTag(AuthTags.Root).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/sample/settings/SettingsPageTest.kt
+++ b/app/src/androidTest/java/com/android/sample/settings/SettingsPageTest.kt
@@ -1,0 +1,43 @@
+package com.android.sample.settings
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingsPageTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun renders_items_and_callbacks_work() {
+    var backClicked = false
+    var signOutClicked = false
+
+    composeRule.setContent {
+      MaterialTheme {
+        SettingsPage(onBackClick = { backClicked = true }, onSignOut = { signOutClicked = true })
+      }
+    }
+
+    // Header and a couple of options
+    composeRule.onNodeWithText("Settings").assertIsDisplayed()
+    composeRule.onNodeWithText("Profile & Account").assertIsDisplayed()
+    composeRule.onNodeWithText("Notifications").assertIsDisplayed()
+
+    // Interactions
+    composeRule.onNodeWithText("Back").performClick()
+    assertTrue(backClicked)
+
+    composeRule.onNodeWithText("Sign Out").performClick()
+    assertTrue(signOutClicked)
+  }
+}


### PR DESCRIPTION
- AppNavE2ETest: SignIn → Home → Settings → back → SignOut happy path
- DrawerContentTest: asserts sections present and toggles/settings/sign-out callbacks
- SettingsPageTest: verifies header, options, back and sign-out callbacks
- MicrosoftFlowE2ETest: validates loading/disable state; @Ignore pending provider/Firebase setup
- ktfmt formatting applied to new test files

