### PR TITLE
Increase JVM heap for unit tests to 2g to address CI OOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -291,6 +291,7 @@ configurations.all {
 }
 
 tasks.withType<Test> {
+    maxHeapSize = "2g"
     // Configure Jacoco for each tests
     configure<JacocoTaskExtension> {
         isIncludeNoLocationClasses = true


### PR DESCRIPTION
Bumps the JVM heap for Gradle Test tasks to 2g to prevent OutOfMemoryErrors during unit tests in CI.
