### PR TITLE
Add Firebase Auth ProGuard rules to fix Microsoft sign-in in release

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,3 +50,25 @@
 -keepclassmembers class * {
     @com.google.gson.annotations.SerializedName <fields>;
 }
+
+# --- Firebase Auth ---
+# Keep Firebase Auth classes (required for OAuthProvider in release builds)
+-keep class com.google.firebase.auth.** { *; }
+-keep class com.google.android.gms.internal.firebase-auth-api.** { *; }
+-dontwarn com.google.firebase.auth.**
+
+# Keep OAuthProvider specifically (used for Microsoft sign-in)
+-keep class com.google.firebase.auth.OAuthProvider { *; }
+-keep class com.google.firebase.auth.OAuthProvider$Builder { *; }
+-keep class com.google.firebase.auth.OAuthCredential { *; }
+
+# Keep Firebase core classes
+-keep class com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+-dontwarn com.google.android.gms.**
+
+# Keep startActivityForSignInWithProvider method
+-keepclassmembers class com.google.firebase.auth.FirebaseAuth {
+    public *** startActivityForSignInWithProvider(...);
+    public *** getPendingAuthResult();
+}


### PR DESCRIPTION
## Problem
After deploying the release APK, clicking "Continue with Microsoft Entra ID" button had no effect - the authentication flow never started. 

## Root Cause
The release build configuration enables code shrinking and obfuscation via ProGuard/R8:
```kotlin
buildTypes {
    release {
        isMinifyEnabled = true
        isShrinkResources = true
        proguardFiles(...)
    }
}
```

While `proguard-rules.pro` contained comprehensive rules for MSAL (Microsoft Authentication Library), it was **missing critical rules for Firebase Auth**. As a result, ProGuard stripped essential Firebase Authentication classes used for OAuth sign-in:

- `com.google.firebase.auth.OAuthProvider`
- `com.google.firebase.auth.OAuthProvider.Builder`
- `FirebaseAuth.startActivityForSignInWithProvider()` method
- `com.google.firebase.auth.OAuthCredential`

Without these classes, the Microsoft sign-in flow in `MicrosoftAuth.kt` silently failed:

```kotlin
// This code was being stripped in release builds
auth.startActivityForSignInWithProvider(activity, builder.build())
    .addOnSuccessListener { result -> ... }
    .addOnFailureListener { exception -> ... }
```

## Solution

Added comprehensive Firebase Auth ProGuard keep rules to prevent class stripping in release builds.

### Changes Made

#### `app/proguard-rules.pro`
Added Firebase Auth protection rules.