### PR TITLE
fix: persist web source display even after the end of the reply's loa…

### DIFF
--- a/app/src/main/java/com/android/sample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/sample/home/HomeViewModel.kt
@@ -204,30 +204,23 @@ class HomeViewModel(
                 if (cid == null) flowOf(emptyList()) else repo.messagesFlow(cid)
               }
               .collect { msgs ->
-
                 val streamingId = _uiState.value.streamingMessageId
                 if (streamingId != null) {
 
                   return@collect
                 }
 
-
                 _uiState.update { currentState ->
                   val firestoreMessages = msgs.map { it.toUi() }
-
 
                   val existingSourceCards =
                       currentState.messages.filter { it.source != null && it.text.isBlank() }
 
-
                   val finalMessages = mutableListOf<ChatUIModel>()
-
 
                   finalMessages.addAll(firestoreMessages)
 
-
                   existingSourceCards.forEach { sourceCard ->
-
                     val originalIndex =
                         currentState.messages.indexOfFirst { it.id == sourceCard.id }
                     if (originalIndex > 0) {


### PR DESCRIPTION
In continuiation of the pr:https://github.com/CS311-Team04/euler/pull/136

**Context:**

After merging with main, I noticed source cards disappear after a few seconds.


**Root cause:**

Source cards are added in startStreaming (lines 522-543 in HomeViewModel) as UI-only items (not in Firestore).
When Firestore emits updates (line 231), the collector replaces the entire messages list: st.copy(messages = msgs.map { it.toUi() }), which removes the source cards.

**Solution implemented:** 
- Collect existing source cards before replacing messages.
- add Firestore messages first, then reinsert source cards after their corresponding assistant message (matched by text).
- if the assistant message isn't in Firestore yet, append the source card at the end

The source cards should now persist and remain visible.