### PR TITLE
Backend Complete Moodle Fetch Pipeline

### DIFF
--- a/app/src/main/java/com/android/sample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/sample/home/HomeViewModel.kt
@@ -835,7 +835,7 @@ class HomeViewModel(
         try {
           repo.appendMessage(cid, "user", msg)
         } catch (e: Exception) {
-          Log.e(TAG, "Failed to persist user message", e)
+          Log.e(TAG, "Failed to persist user message: ${e.message}", e)
           handleSendMessageError(e, aiMessageId)
           return@launch
         }

--- a/functions/src/intentDetection.ts
+++ b/functions/src/intentDetection.ts
@@ -79,10 +79,10 @@ const ED_BLOCK_PATTERNS: RegExp[] = [
  * These patterns prevent false positives when users ask about Moodle itself
  */
 const MOODLE_BLOCK_PATTERNS: RegExp[] = [
-  /\b(c['']?est\s+quoi|qu['']?est[- ]ce\s+que?)\b.*\bmoodle\b/i,
-  /\bcomment\s+(marche|fonctionne|utiliser?)\b.*\bmoodle\b/i,
-  /\b(où|ou)\s+(trouver?|est)\b.*\bmoodle\b/i,
-  /\bexplique[rz]?\b.*\bmoodle\b/i,
+  /\b(c['']?est\s+quoi|qu['']?est[- ]ce\s+que?)\b.{0,50}\bmoodle\b/i,
+  /\bcomment\s+(marche|fonctionne|utiliser?)\b.{0,50}\bmoodle\b/i,
+  /\b(où|ou)\s+(trouver?|est)\b.{0,50}\bmoodle\b/i,
+  /\bexplique[rz]?\b.{0,50}\bmoodle\b/i,
 ];
 
 /**
@@ -118,15 +118,20 @@ export const MOODLE_INTENT_CONFIGS: IntentConfig[] = [
   // ===== GENERAL MOODLE FETCH INTENT =====
   // This is the first layer detection - catches any "fetch me the..." type request
   // The specific file type (lecture/homework/solution) is determined in the second layer
+  // Note: These patterns are intentionally broad to catch various phrasings. False positives
+  // are filtered out in the second layer (moodleIntent.ts) which requires Moodle-specific
+  // keywords (lecture, homework, solution, cours, etc.) or explicit "moodle" mentions.
   {
     id: "fetch_file",
     matchPatterns: [
-      // English patterns
-      /\b(fetch|get|show|display|download|retrieve|bring)\s+(me\s+)?(the\s+)?/i,
-      /\b(i\s+)?(want|need|would\s+like)\s+(to\s+)?(fetch|get|see|view|download|retrieve)\s+(the\s+)?/i,
-      // French patterns - "donne" (give), "récupère" (fetch), etc.
-      /\b(donne|donner?|récupérer?|obtenir?|télécharger?|charger?|voir|afficher?|montrer?|ouvrir?|chercher?|trouver?)\s+(moi\s+)?(le\s+|la\s+|les\s+)?/i,
-      /\b(je\s+)?(veux|voudrais|souhaite|ai\s+besoin)\s+(de\s+)?(récupérer?|obtenir?|voir|afficher?|télécharger?|donner?)\s+(le\s+|la\s+|les\s+)?/i,
+      // English patterns - require file-related context or explicit moodle mention
+      /\b(fetch|get|show|display|download|retrieve|bring)\s+(me\s+)?(the\s+)?(lecture|homework|solution|file|document|cours|moodle)/i,
+      /\b(fetch|get|show|display|download|retrieve|bring)\s+(me\s+)?(the\s+).*\bmoodle\b/i,
+      /\b(i\s+)?(want|need|would\s+like)\s+(to\s+)?(fetch|get|see|view|download|retrieve)\s+(the\s+)?(lecture|homework|solution|file|document|cours|moodle)/i,
+      // French patterns - require file-related context or explicit moodle mention
+      /\b(donne|donner?|récupérer?|obtenir?|télécharger?|charger?|voir|afficher?|montrer?|ouvrir?|chercher?|trouver?)\s+(moi\s+)?(le\s+|la\s+|les\s+)?(cours|devoir|lecture|fichier|document|moodle)/i,
+      /\b(donne|donner?|récupérer?|obtenir?|télécharger?|charger?|voir|afficher?|montrer?|ouvrir?|chercher?|trouver?)\s+(moi\s+)?(le\s+|la\s+|les\s+)?.*\bmoodle\b/i,
+      /\b(je\s+)?(veux|voudrais|souhaite|ai\s+besoin)\s+(de\s+)?(récupérer?|obtenir?|voir|afficher?|télécharger?|donner?)\s+(le\s+|la\s+|les\s+)?(cours|devoir|lecture|fichier|document|moodle)/i,
       // Patterns that include file type keywords (lecture, homework, etc.)
       /\b(lecture|leçon|lesson|devoir|homework|home\s*work|travail|solution|correction|corrigé|cours)\s+(\d+|[a-z])/i,
       // Patterns with "cours" (course) and "semaine" (week) - common French patterns


### PR DESCRIPTION
**Description**
Implements end-to-end Moodle integration to detect lecture/homework/solution requests, match the correct course (including abbreviations), locate the exact file by type and number, and return a direct, URL-safe PDF link.

**What**
Added intent detection via regex with priority ordering (solution > homework > lecture) and numeric extraction. Course matching uses fullname + shortname with normalization (e.g., "entreprise" → "enterprise") to handle variants. File selection requires exact type+number in module names to avoid wrong-file returns. Moodle API calls fetch enrolled courses, course contents, and matching resources, then append token + forcedownload and follow redirects for direct PDF URLs. All returned URLs are percent-encoded to handle spaces and special characters.

**Why**
No Moodle support existed. Users needed to ask "lecture/homework/solution X from [course]" and get the right PDF, even with course-name variations and filenames containing spaces or special characters.

**How**
Built a detection layer to parse user intent and extract file type + number. Implemented course matching with string normalization for flexible name handling. Connected to Moodle REST API to fetch user courses, locate resources, and resolve direct download URLs with proper encoding to prevent client-side parsing failures.

**Testing**
Manual requests across multiple courses (e.g., algebra, software enterprise/swent) for lecture/homework/solution 1/2; verified correct file is returned and no URL-format errors.

ps: I used an llm for the code and tests