### PR TITLE
feat(ED-posting): adding the drop down menu for course selection and anonymous Mode

### DIFF
--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -601,9 +601,11 @@ fun HomeScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     title = edPostAction.draftTitle,
                                     body = edPostAction.draftBody,
-                                    isLoading = ui.isPostingToEd,
-                                    onPublish = { title, body ->
-                                      viewModel.publishEdPost(title, body)
+                                    courses = ui.edCourses,
+                                    selectedCourseId = null,
+                                    isLoading = ui.isPostingToEd || ui.isLoadingEdCourses,
+                                    onPublish = { title, body, courseId, isAnonymous ->
+                                      viewModel.publishEdPost(title, body, courseId, isAnonymous)
                                     },
                                     onCancel = { viewModel.cancelEdPost() })
                                 Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -602,7 +602,7 @@ fun HomeScreen(
                                     title = edPostAction.draftTitle,
                                     body = edPostAction.draftBody,
                                     courses = ui.edCourses,
-                                    selectedCourseId = null,
+                                    selectedCourseId = edPostAction.selectedCourseId,
                                     isLoading = ui.isPostingToEd || ui.isLoadingEdCourses,
                                     onPublish = { title, body, courseId, isAnonymous ->
                                       viewModel.publishEdPost(title, body, courseId, isAnonymous)

--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -603,7 +603,8 @@ fun HomeScreen(
                                     body = edPostAction.draftBody,
                                     courses = ui.edCourses,
                                     selectedCourseId = edPostAction.selectedCourseId,
-                                    isLoading = ui.isPostingToEd || ui.isLoadingEdCourses,
+                                    isLoading = ui.isPostingToEd,
+                                    isLoadingCourses = ui.isLoadingEdCourses,
                                     onPublish = { title, body, courseId, isAnonymous ->
                                       viewModel.publishEdPost(title, body, courseId, isAnonymous)
                                     },

--- a/app/src/main/java/com/android/sample/home/HomeUIState.kt
+++ b/app/src/main/java/com/android/sample/home/HomeUIState.kt
@@ -57,7 +57,8 @@ sealed class PendingAction {
   data class PostOnEd(
       val draftTitle: String,
       val draftBody: String,
-      val messageId: String? = null
+      val messageId: String? = null,
+      val selectedCourseId: Long? = null
   ) : PendingAction()
 }
 

--- a/app/src/main/java/com/android/sample/home/HomeUIState.kt
+++ b/app/src/main/java/com/android/sample/home/HomeUIState.kt
@@ -31,7 +31,9 @@ data class HomeUiState(
     val edPostsCards: List<EdPostsCard> =
         emptyList(), // Cards for fetched posts, associated with messages
     val isPostingToEd: Boolean = false,
-    val edPostsState: EdPostsUiState = EdPostsUiState(stage = EdPostsStage.IDLE)
+    val edPostsState: EdPostsUiState = EdPostsUiState(stage = EdPostsStage.IDLE),
+    val edCourses: List<EdCourse> = emptyList(),
+    val isLoadingEdCourses: Boolean = false
 )
 
 /** Represents an EPFL system (e.g., IS-Academia, Moodle, Drive) and its connection state. */

--- a/app/src/main/java/com/android/sample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/sample/home/HomeViewModel.kt
@@ -1944,6 +1944,7 @@ class HomeViewModel(
       Log.d(TAG, "ED intent detected: ${reply.edIntent.intent} - creating PostOnEd pending action")
       val formattedQuestion = reply.edIntent.formattedQuestion ?: originalQuestion
       val formattedTitle = reply.edIntent.formattedTitle ?: ""
+      val suggestedCourseId = reply.edIntent.suggestedCourseId
 
       // Load courses when ED post intent is detected
       loadEdCourses()
@@ -1954,7 +1955,8 @@ class HomeViewModel(
                 PendingAction.PostOnEd(
                     draftTitle = formattedTitle,
                     draftBody = formattedQuestion,
-                    messageId = messageId),
+                    messageId = messageId,
+                    selectedCourseId = suggestedCourseId),
             messages = state.messages.filterNot { it.id == messageId && it.type == ChatType.AI },
             streamingMessageId = null,
             isSending = false)

--- a/app/src/main/java/com/android/sample/llm/HttpLlmClient.kt
+++ b/app/src/main/java/com/android/sample/llm/HttpLlmClient.kt
@@ -159,12 +159,14 @@ internal fun parseBotReply(body: String, gson: Gson): BotReply {
   val edIntentType = json.getTrimmedString(JSON_KEY_ED_INTENT)
   val edFormattedQuestion = json.getTrimmedString(JSON_KEY_ED_FORMATTED_QUESTION)
   val edFormattedTitle = json.getTrimmedString(JSON_KEY_ED_FORMATTED_TITLE)
+  val edSuggestedCourseId = json.optLong(JSON_KEY_ED_SUGGESTED_COURSE_ID)
   val edIntent =
       com.android.sample.llm.EdIntent(
           detected = edIntentDetected,
           intent = edIntentType,
           formattedQuestion = edFormattedQuestion,
-          formattedTitle = edFormattedTitle)
+          formattedTitle = edFormattedTitle,
+          suggestedCourseId = edSuggestedCourseId)
 
   val edFetchIntent =
       com.android.sample.llm.EdFetchIntent(
@@ -207,6 +209,17 @@ private fun JsonObject.optString(key: String, defaultValue: String?): String? {
   return value.takeIf { it.isNotEmpty() } ?: defaultValue
 }
 
+private fun JsonObject.optLong(key: String, defaultValue: Long = -1): Long? {
+  val element: JsonElement = get(key) ?: return null
+  if (element.isJsonNull || !element.isJsonPrimitive) return null
+  val primitive = element.asJsonPrimitive
+  return when {
+    primitive.isNumber -> primitive.asLong
+    primitive.isString -> primitive.asString.toLongOrNull()
+    else -> null
+  }?.takeIf { it >= 0 } ?: null
+}
+
 private const val HEADER_CONTENT_TYPE = "Content-Type"
 private const val HEADER_AUTHORIZATION = "Authorization"
 private const val AUTH_SCHEME_BEARER = "Bearer"
@@ -222,6 +235,7 @@ private const val JSON_KEY_ED_INTENT_DETECTED = "ed_intent_detected"
 private const val JSON_KEY_ED_INTENT = "ed_intent"
 private const val JSON_KEY_ED_FORMATTED_QUESTION = "ed_formatted_question"
 private const val JSON_KEY_ED_FORMATTED_TITLE = "ed_formatted_title"
+private const val JSON_KEY_ED_SUGGESTED_COURSE_ID = "ed_suggested_course_id"
 private const val JSON_KEY_ED_FETCH_INTENT_DETECTED = "ed_fetch_intent_detected"
 private const val JSON_KEY_ED_FETCH_QUERY = "ed_fetch_query"
 // Standard localhost identifier - safe loopback address (RFC 5735)

--- a/app/src/main/java/com/android/sample/llm/HttpLlmClient.kt
+++ b/app/src/main/java/com/android/sample/llm/HttpLlmClient.kt
@@ -23,7 +23,17 @@ import okhttp3.RequestBody.Companion.toRequestBody
  * backend is expected to accept a JSON payload `{"question": "<prompt>"}` and respond with
  * `{"reply": "<text>"}`. Any deviation throws an [IllegalStateException] that the caller can
  * surface to the UI.
+ *
+ * @deprecated This class is no longer used. The project now uses Firebase Cloud Functions instead
+ *   of direct HTTP endpoints. This class is kept for backward compatibility but should not be used
+ *   in new code.
  */
+@Deprecated(
+    message = "HttpLlmClient is deprecated. Use FirebaseFunctionsLlmClient instead.",
+    replaceWith =
+        ReplaceWith(
+            "FirebaseFunctionsLlmClient", "com.android.sample.llm.FirebaseFunctionsLlmClient"),
+    level = DeprecationLevel.WARNING)
 class HttpLlmClient(
     private val endpoint: String = BuildConfig.LLM_HTTP_ENDPOINT,
     private val apiKey: String = BuildConfig.LLM_HTTP_API_KEY,

--- a/app/src/main/java/com/android/sample/llm/LlmClient.kt
+++ b/app/src/main/java/com/android/sample/llm/LlmClient.kt
@@ -126,8 +126,8 @@ interface LlmClient {
  * Production [LlmClient] relying on Firebase callable Cloud Functions.
  *
  * Uses the `answerWithRagFn` callable function and applies a short timeout. It optionally falls
- * back to [HttpLlmClient] (when configured) if the primary call times out or the response payload
- * is invalid. The fallback is handy for local development with a plain HTTP server.
+ * back to a fallback [LlmClient] (when configured) if the primary call times out or the response
+ * payload is invalid. The fallback is handy for local development.
  */
 class FirebaseFunctionsLlmClient(
     private val functions: FirebaseFunctions = defaultFunctions(),

--- a/app/src/main/java/com/android/sample/llm/LlmClient.kt
+++ b/app/src/main/java/com/android/sample/llm/LlmClient.kt
@@ -40,12 +40,14 @@ enum class SourceType {
  * @param intent The type of ED intent detected (e.g., "post_question")
  * @param formattedQuestion The formatted question for ED post (when detected is true)
  * @param formattedTitle The formatted title for ED post (when detected is true)
+ * @param suggestedCourseId The suggested course ID detected from the prompt (when detected is true)
  */
 data class EdIntent(
     val detected: Boolean = false,
     val intent: String? = null,
     val formattedQuestion: String? = null,
-    val formattedTitle: String? = null
+    val formattedTitle: String? = null,
+    val suggestedCourseId: Long? = null
 )
 
 /**
@@ -240,6 +242,15 @@ class FirebaseFunctionsLlmClient(
   private fun parseEdFormattedTitle(map: Map<String, Any?>): String? =
       map[KEY_ED_FORMATTED_TITLE] as? String
 
+  private fun parseEdSuggestedCourseId(map: Map<String, Any?>): Long? {
+    val value = map[KEY_ED_SUGGESTED_COURSE_ID] ?: return null
+    return when (value) {
+      is Number -> value.toLong()
+      is String -> value.toLongOrNull()
+      else -> null
+    }?.takeIf { it >= 0 }
+  }
+
   private fun parseEdFetchIntentDetected(map: Map<String, Any?>): Boolean =
       map[KEY_ED_FETCH_INTENT_DETECTED] as? Boolean ?: false
 
@@ -254,12 +265,14 @@ class FirebaseFunctionsLlmClient(
 
     val edFormattedQuestion = parseEdFormattedQuestion(map)
     val edFormattedTitle = parseEdFormattedTitle(map)
+    val edSuggestedCourseId = parseEdSuggestedCourseId(map)
     val edIntent =
         EdIntent(
             detected = edIntentDetected,
             intent = edIntentType,
             formattedQuestion = edFormattedQuestion,
-            formattedTitle = edFormattedTitle)
+            formattedTitle = edFormattedTitle,
+            suggestedCourseId = edSuggestedCourseId)
 
     val edFetchDetected = parseEdFetchIntentDetected(map)
     val edFetchQuery = parseEdFetchQuery(map)
@@ -296,6 +309,7 @@ class FirebaseFunctionsLlmClient(
     private const val KEY_ED_INTENT = "ed_intent"
     private const val KEY_ED_FORMATTED_QUESTION = "ed_formatted_question"
     private const val KEY_ED_FORMATTED_TITLE = "ed_formatted_title"
+    private const val KEY_ED_SUGGESTED_COURSE_ID = "ed_suggested_course_id"
     private const val KEY_ED_FETCH_INTENT_DETECTED = "ed_fetch_intent_detected"
     private const val KEY_ED_FETCH_QUERY = "ed_fetch_query"
 

--- a/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
+++ b/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
@@ -81,247 +81,305 @@ fun EdPostConfirmationModal(
           Column(
               modifier = Modifier.fillMaxWidth().padding(EdPostDimensions.ContentHorizontalPadding),
               verticalArrangement = Arrangement.spacedBy(EdPostDimensions.ContentVerticalSpacing)) {
-                // Course selection dropdown
-                if (courses.isNotEmpty() || isLoadingCourses) {
-                  ExposedDropdownMenuBox(
-                      expanded = courseDropdownExpanded && !isLoadingCourses,
-                      onExpandedChange = {
-                        if (!isLoadingCourses) courseDropdownExpanded = !courseDropdownExpanded
-                      }) {
-                        val selectedCourse = courses.find { it.id == currentSelectedCourseId }
-                        val displayText =
-                            selectedCourse?.let { "${it.code ?: ""} ${it.name}".trim() }
-                                ?: stringResource(R.string.select_course)
+                CourseDropdown(
+                    courses = courses,
+                    selectedCourseId = currentSelectedCourseId,
+                    onCourseSelected = { currentSelectedCourseId = it },
+                    courseDropdownExpanded = courseDropdownExpanded,
+                    onExpandedChange = { courseDropdownExpanded = it },
+                    isLoading = isLoading,
+                    isLoadingCourses = isLoadingCourses,
+                    textSecondary = textSecondary)
 
-                        OutlinedTextField(
-                            value = displayText,
-                            onValueChange = {},
-                            readOnly = true,
-                            enabled = !isLoading && !isLoadingCourses,
-                            modifier = Modifier.fillMaxWidth().menuAnchor(),
-                            placeholder = {
-                              Text(
-                                  text = stringResource(R.string.select_course),
-                                  color = textSecondary,
-                                  fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
-                            },
-                            textStyle =
-                                MaterialTheme.typography.bodyLarge.copy(
-                                    fontSize = EdPostDimensions.TextFieldBodyFontSize,
-                                    color = EdPostTextPrimary),
-                            colors =
-                                OutlinedTextFieldDefaults.colors(
-                                    focusedTextColor = EdPostTextPrimary,
-                                    unfocusedTextColor = EdPostTextPrimary,
-                                    focusedBorderColor = EdPostTransparent,
-                                    unfocusedBorderColor = EdPostTransparent,
-                                    focusedContainerColor = EdPostTextFieldContainer,
-                                    unfocusedContainerColor = EdPostTextFieldContainer),
-                            shape = RoundedCornerShape(EdPostDimensions.TextFieldBodyCornerRadius),
-                            trailingIcon = {
-                              if (isLoadingCourses) {
-                                CircularProgressIndicator(
-                                    color = EdPostIconSecondary,
-                                    strokeWidth = EdPostDimensions.IconLoadingSpinnerStrokeWidth,
-                                    modifier =
-                                        Modifier.size(EdPostDimensions.IconLoadingSpinnerSize))
-                              } else {
-                                ExposedDropdownMenuDefaults.TrailingIcon(
-                                    expanded = courseDropdownExpanded)
-                              }
-                            })
-
-                        ExposedDropdownMenu(
-                            expanded = courseDropdownExpanded,
-                            onDismissRequest = { courseDropdownExpanded = false },
-                            modifier = Modifier.background(EdPostTextFieldContainer)) {
-                              courses.forEach { course ->
-                                DropdownMenuItem(
-                                    text = {
-                                      Text(
-                                          text = "${course.code ?: ""} ${course.name}".trim(),
-                                          color = EdPostTextPrimary)
-                                    },
-                                    onClick = {
-                                      currentSelectedCourseId = course.id
-                                      courseDropdownExpanded = false
-                                    })
-                              }
-                            }
-                      }
-                }
-
-                // Title capsule row
-                OutlinedTextField(
-                    value = editedTitle,
-                    onValueChange = { editedTitle = it },
+                EdPostTitleField(
+                    title = editedTitle,
+                    onTitleChange = { editedTitle = it },
                     enabled = !isLoading,
-                    modifier = Modifier.fillMaxWidth(),
-                    placeholder = {
-                      Text(
-                          text = stringResource(R.string.ed_post_title_placeholder),
-                          color = textSecondary,
-                          fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
-                    },
-                    textStyle =
-                        MaterialTheme.typography.titleLarge.copy(
-                            fontSize = EdPostDimensions.TextFieldTitleFontSize,
-                            fontWeight = FontWeight.Bold,
-                            color = EdPostTextPrimary),
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = EdPostTextPrimary,
-                            unfocusedTextColor = EdPostTextPrimary,
-                            cursorColor = EdPostTextPrimary,
-                            focusedBorderColor = EdPostTransparent,
-                            unfocusedBorderColor = EdPostTransparent,
-                            focusedContainerColor = EdPostTextFieldContainer,
-                            unfocusedContainerColor = EdPostTextFieldContainer),
-                    shape = RoundedCornerShape(EdPostDimensions.TextFieldTitleCornerRadius),
-                    singleLine = true,
-                    trailingIcon = {
-                      Icon(
-                          imageVector = Icons.Outlined.Edit,
-                          contentDescription = "Edit title",
-                          tint = EdPostIconSecondary,
-                          modifier = Modifier.size(EdPostDimensions.IconEditSize))
-                    })
+                    textSecondary = textSecondary)
 
-                // Body text field (multiline)
-                OutlinedTextField(
-                    value = editedBody,
-                    onValueChange = { editedBody = it },
+                EdPostBodyField(
+                    body = editedBody,
+                    onBodyChange = { editedBody = it },
                     enabled = !isLoading,
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .heightIn(
-                                min = EdPostDimensions.TextFieldBodyMinHeight,
-                                max = EdPostDimensions.TextFieldBodyMaxHeight),
-                    placeholder = {
-                      Text(
-                          text = stringResource(R.string.ed_post_body_placeholder),
-                          color = textSecondary,
-                          fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
+                    textSecondary = textSecondary)
+
+                AnonymousToggle(
+                    isAnonymous = isAnonymous,
+                    onAnonymousChange = { isAnonymous = it },
+                    enabled = !isLoading,
+                    isDark = isDark,
+                    colorScheme = colorScheme)
+
+                EdPostActionButtons(
+                    isLoading = isLoading,
+                    canPost = currentSelectedCourseId != null,
+                    onPublish = {
+                      onPublish(editedTitle, editedBody, currentSelectedCourseId, isAnonymous)
                     },
-                    textStyle =
-                        MaterialTheme.typography.bodyLarge.copy(
-                            fontSize = EdPostDimensions.TextFieldBodyFontSize,
-                            color = EdPostTextPrimary,
-                            lineHeight = EdPostDimensions.TextFieldBodyLineHeight),
-                    colors =
-                        OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = EdPostTextPrimary,
-                            unfocusedTextColor = EdPostTextPrimary,
-                            cursorColor = EdPostTextPrimary,
-                            focusedBorderColor = EdPostTransparent,
-                            unfocusedBorderColor = EdPostTransparent,
-                            focusedContainerColor = EdPostTextFieldContainer,
-                            unfocusedContainerColor = EdPostTextFieldContainer),
-                    shape = RoundedCornerShape(EdPostDimensions.TextFieldBodyCornerRadius),
-                    maxLines = EdPostDimensions.TextFieldBodyMaxLines,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default))
-
-                // Anonymous post toggle
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween) {
-                      Text(
-                          text = stringResource(R.string.post_anonymously),
-                          style =
-                              MaterialTheme.typography.bodyMedium.copy(
-                                  fontSize = EdPostDimensions.TextFieldBodyFontSize,
-                                  color = EdPostTextPrimary))
-                      Switch(
-                          checked = isAnonymous,
-                          onCheckedChange = { isAnonymous = it },
-                          enabled = !isLoading,
-                          colors =
-                              SwitchDefaults.colors(
-                                  checkedThumbColor = ed1,
-                                  checkedTrackColor = ed1.copy(alpha = 0.5f),
-                                  uncheckedThumbColor =
-                                      if (isDark) colorScheme.outline
-                                      else colorScheme.outlineVariant,
-                                  uncheckedTrackColor =
-                                      if (isDark) colorScheme.surfaceVariant
-                                      else colorScheme.surfaceVariant.copy(alpha = 0.6f)))
-                    }
-
-                // Action buttons row
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(EdPostDimensions.ButtonSpacing)) {
-                      // Cancel button (outline)
-                      OutlinedButton(
-                          onClick = onCancel,
-                          enabled = !isLoading,
-                          modifier = Modifier.weight(1f),
-                          colors =
-                              ButtonDefaults.outlinedButtonColors(contentColor = EdPostTextPrimary),
-                          shape = RoundedCornerShape(EdPostDimensions.ButtonCancelCornerRadius),
-                          border =
-                              BorderStroke(
-                                  EdPostDimensions.ButtonBorderWidth, EdPostBorderSecondary)) {
-                            Text(
-                                text = stringResource(R.string.ed_post_cancel_button),
-                                fontSize = EdPostDimensions.ButtonTextFontSize,
-                                fontWeight = FontWeight.Medium)
-                          }
-
-                      // Post button (gradient purple)
-                      // Disable button if no course is selected
-                      val canPost = !isLoading && currentSelectedCourseId != null
-                      Button(
-                          onClick = {
-                            onPublish(editedTitle, editedBody, currentSelectedCourseId, isAnonymous)
-                          },
-                          enabled = canPost,
-                          modifier = Modifier.weight(1f),
-                          colors = ButtonDefaults.buttonColors(containerColor = EdPostTransparent),
-                          contentPadding = PaddingValues(),
-                          shape = RoundedCornerShape(EdPostDimensions.ButtonPostCornerRadius)) {
-                            Box(
-                                modifier =
-                                    Modifier.background(
-                                            brush = gradient,
-                                            shape =
-                                                RoundedCornerShape(
-                                                    EdPostDimensions.ButtonGradientCornerRadius))
-                                        .fillMaxWidth()
-                                        .padding(vertical = EdPostDimensions.ButtonVerticalPadding),
-                                contentAlignment = Alignment.Center) {
-                                  Row(
-                                      horizontalArrangement = Arrangement.Center,
-                                      verticalAlignment = Alignment.CenterVertically) {
-                                        Text(
-                                            text = stringResource(R.string.ed_post_post_button),
-                                            fontSize = EdPostDimensions.ButtonTextFontSize,
-                                            fontWeight = FontWeight.Bold,
-                                            color = EdPostTextPrimary)
-                                        Spacer(
-                                            modifier =
-                                                Modifier.width(
-                                                    EdPostDimensions.ButtonIconSpacerWidth))
-                                        if (isLoading) {
-                                          CircularProgressIndicator(
-                                              color = EdPostTextPrimary,
-                                              strokeWidth = EdPostDimensions.ButtonBorderWidth,
-                                              modifier =
-                                                  Modifier.size(EdPostDimensions.IconSendSize))
-                                        } else {
-                                          Icon(
-                                              imageVector = Icons.AutoMirrored.Rounded.Send,
-                                              contentDescription = null,
-                                              modifier =
-                                                  Modifier.size(EdPostDimensions.IconSendSize),
-                                              tint = EdPostTextPrimary)
-                                        }
-                                      }
-                                }
-                          }
-                    }
+                    onCancel = onCancel,
+                    gradient = gradient)
               }
         }
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CourseDropdown(
+    courses: List<EdCourse>,
+    selectedCourseId: Long?,
+    onCourseSelected: (Long) -> Unit,
+    courseDropdownExpanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    isLoading: Boolean,
+    isLoadingCourses: Boolean,
+    textSecondary: androidx.compose.ui.graphics.Color
+) {
+  if (courses.isNotEmpty() || isLoadingCourses) {
+    ExposedDropdownMenuBox(
+        expanded = courseDropdownExpanded && !isLoadingCourses,
+        onExpandedChange = { if (!isLoadingCourses) onExpandedChange(!courseDropdownExpanded) }) {
+          val selectedCourse = courses.find { it.id == selectedCourseId }
+          val displayText =
+              selectedCourse?.let { "${it.code ?: ""} ${it.name}".trim() }
+                  ?: stringResource(R.string.select_course)
+
+          OutlinedTextField(
+              value = displayText,
+              onValueChange = {},
+              readOnly = true,
+              enabled = !isLoading && !isLoadingCourses,
+              modifier = Modifier.fillMaxWidth().menuAnchor(),
+              placeholder = {
+                Text(
+                    text = stringResource(R.string.select_course),
+                    color = textSecondary,
+                    fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
+              },
+              textStyle =
+                  MaterialTheme.typography.bodyLarge.copy(
+                      fontSize = EdPostDimensions.TextFieldBodyFontSize, color = EdPostTextPrimary),
+              colors =
+                  OutlinedTextFieldDefaults.colors(
+                      focusedTextColor = EdPostTextPrimary,
+                      unfocusedTextColor = EdPostTextPrimary,
+                      focusedBorderColor = EdPostTransparent,
+                      unfocusedBorderColor = EdPostTransparent,
+                      focusedContainerColor = EdPostTextFieldContainer,
+                      unfocusedContainerColor = EdPostTextFieldContainer),
+              shape = RoundedCornerShape(EdPostDimensions.TextFieldBodyCornerRadius),
+              trailingIcon = {
+                if (isLoadingCourses) {
+                  CircularProgressIndicator(
+                      color = EdPostIconSecondary,
+                      strokeWidth = EdPostDimensions.IconLoadingSpinnerStrokeWidth,
+                      modifier = Modifier.size(EdPostDimensions.IconLoadingSpinnerSize))
+                } else {
+                  ExposedDropdownMenuDefaults.TrailingIcon(expanded = courseDropdownExpanded)
+                }
+              })
+
+          ExposedDropdownMenu(
+              expanded = courseDropdownExpanded,
+              onDismissRequest = { onExpandedChange(false) },
+              modifier = Modifier.background(EdPostTextFieldContainer)) {
+                courses.forEach { course ->
+                  DropdownMenuItem(
+                      text = {
+                        Text(
+                            text = "${course.code ?: ""} ${course.name}".trim(),
+                            color = EdPostTextPrimary)
+                      },
+                      onClick = {
+                        onCourseSelected(course.id)
+                        onExpandedChange(false)
+                      })
+                }
+              }
+        }
+  }
+}
+
+@Composable
+private fun EdPostTitleField(
+    title: String,
+    onTitleChange: (String) -> Unit,
+    enabled: Boolean,
+    textSecondary: androidx.compose.ui.graphics.Color
+) {
+  OutlinedTextField(
+      value = title,
+      onValueChange = onTitleChange,
+      enabled = enabled,
+      modifier = Modifier.fillMaxWidth(),
+      placeholder = {
+        Text(
+            text = stringResource(R.string.ed_post_title_placeholder),
+            color = textSecondary,
+            fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
+      },
+      textStyle =
+          MaterialTheme.typography.titleLarge.copy(
+              fontSize = EdPostDimensions.TextFieldTitleFontSize,
+              fontWeight = FontWeight.Bold,
+              color = EdPostTextPrimary),
+      colors =
+          OutlinedTextFieldDefaults.colors(
+              focusedTextColor = EdPostTextPrimary,
+              unfocusedTextColor = EdPostTextPrimary,
+              cursorColor = EdPostTextPrimary,
+              focusedBorderColor = EdPostTransparent,
+              unfocusedBorderColor = EdPostTransparent,
+              focusedContainerColor = EdPostTextFieldContainer,
+              unfocusedContainerColor = EdPostTextFieldContainer),
+      shape = RoundedCornerShape(EdPostDimensions.TextFieldTitleCornerRadius),
+      singleLine = true,
+      trailingIcon = {
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = "Edit title",
+            tint = EdPostIconSecondary,
+            modifier = Modifier.size(EdPostDimensions.IconEditSize))
+      })
+}
+
+@Composable
+private fun EdPostBodyField(
+    body: String,
+    onBodyChange: (String) -> Unit,
+    enabled: Boolean,
+    textSecondary: androidx.compose.ui.graphics.Color
+) {
+  OutlinedTextField(
+      value = body,
+      onValueChange = onBodyChange,
+      enabled = enabled,
+      modifier =
+          Modifier.fillMaxWidth()
+              .heightIn(
+                  min = EdPostDimensions.TextFieldBodyMinHeight,
+                  max = EdPostDimensions.TextFieldBodyMaxHeight),
+      placeholder = {
+        Text(
+            text = stringResource(R.string.ed_post_body_placeholder),
+            color = textSecondary,
+            fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
+      },
+      textStyle =
+          MaterialTheme.typography.bodyLarge.copy(
+              fontSize = EdPostDimensions.TextFieldBodyFontSize,
+              color = EdPostTextPrimary,
+              lineHeight = EdPostDimensions.TextFieldBodyLineHeight),
+      colors =
+          OutlinedTextFieldDefaults.colors(
+              focusedTextColor = EdPostTextPrimary,
+              unfocusedTextColor = EdPostTextPrimary,
+              cursorColor = EdPostTextPrimary,
+              focusedBorderColor = EdPostTransparent,
+              unfocusedBorderColor = EdPostTransparent,
+              focusedContainerColor = EdPostTextFieldContainer,
+              unfocusedContainerColor = EdPostTextFieldContainer),
+      shape = RoundedCornerShape(EdPostDimensions.TextFieldBodyCornerRadius),
+      maxLines = EdPostDimensions.TextFieldBodyMaxLines,
+      keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default))
+}
+
+@Composable
+private fun AnonymousToggle(
+    isAnonymous: Boolean,
+    onAnonymousChange: (Boolean) -> Unit,
+    enabled: Boolean,
+    isDark: Boolean,
+    colorScheme: ColorScheme
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            text = stringResource(R.string.post_anonymously),
+            style =
+                MaterialTheme.typography.bodyMedium.copy(
+                    fontSize = EdPostDimensions.TextFieldBodyFontSize, color = EdPostTextPrimary))
+        Switch(
+            checked = isAnonymous,
+            onCheckedChange = onAnonymousChange,
+            enabled = enabled,
+            colors =
+                SwitchDefaults.colors(
+                    checkedThumbColor = ed1,
+                    checkedTrackColor = ed1.copy(alpha = 0.5f),
+                    uncheckedThumbColor =
+                        if (isDark) colorScheme.outline else colorScheme.outlineVariant,
+                    uncheckedTrackColor =
+                        if (isDark) colorScheme.surfaceVariant
+                        else colorScheme.surfaceVariant.copy(alpha = 0.6f)))
+      }
+}
+
+@Composable
+private fun EdPostActionButtons(
+    isLoading: Boolean,
+    canPost: Boolean,
+    onPublish: () -> Unit,
+    onCancel: () -> Unit,
+    gradient: Brush
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(EdPostDimensions.ButtonSpacing)) {
+        OutlinedButton(
+            onClick = onCancel,
+            enabled = !isLoading,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = EdPostTextPrimary),
+            shape = RoundedCornerShape(EdPostDimensions.ButtonCancelCornerRadius),
+            border = BorderStroke(EdPostDimensions.ButtonBorderWidth, EdPostBorderSecondary)) {
+              Text(
+                  text = stringResource(R.string.ed_post_cancel_button),
+                  fontSize = EdPostDimensions.ButtonTextFontSize,
+                  fontWeight = FontWeight.Medium)
+            }
+
+        Button(
+            onClick = onPublish,
+            enabled = canPost,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.buttonColors(containerColor = EdPostTransparent),
+            contentPadding = PaddingValues(),
+            shape = RoundedCornerShape(EdPostDimensions.ButtonPostCornerRadius)) {
+              Box(
+                  modifier =
+                      Modifier.background(
+                              brush = gradient,
+                              shape =
+                                  RoundedCornerShape(EdPostDimensions.ButtonGradientCornerRadius))
+                          .fillMaxWidth()
+                          .padding(vertical = EdPostDimensions.ButtonVerticalPadding),
+                  contentAlignment = Alignment.Center) {
+                    Row(
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically) {
+                          Text(
+                              text = stringResource(R.string.ed_post_post_button),
+                              fontSize = EdPostDimensions.ButtonTextFontSize,
+                              fontWeight = FontWeight.Bold,
+                              color = EdPostTextPrimary)
+                          Spacer(modifier = Modifier.width(EdPostDimensions.ButtonIconSpacerWidth))
+                          if (isLoading) {
+                            CircularProgressIndicator(
+                                color = EdPostTextPrimary,
+                                strokeWidth = EdPostDimensions.ButtonBorderWidth,
+                                modifier = Modifier.size(EdPostDimensions.IconSendSize))
+                          } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.Send,
+                                contentDescription = null,
+                                modifier = Modifier.size(EdPostDimensions.IconSendSize),
+                                tint = EdPostTextPrimary)
+                          }
+                        }
+                  }
+            }
       }
 }

--- a/app/src/main/java/com/android/sample/ui/theme/EdPostDimensions.kt
+++ b/app/src/main/java/com/android/sample/ui/theme/EdPostDimensions.kt
@@ -38,6 +38,8 @@ object EdPostDimensions {
   val IconEditSize = 18.dp
   val IconSendSize = 18.dp
   val IconStatusSize = 16.dp
+  val IconLoadingSpinnerSize = 20.dp
+  val IconLoadingSpinnerStrokeWidth = 2.dp
 
   // ========== Button Dimensions ==========
   val ButtonCancelCornerRadius = 10.dp

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,8 @@
     <string name="ed_post_body_placeholder">Votre question pour ED…</string>
     <string name="ed_post_cancel_button">Cancel</string>
     <string name="ed_post_post_button">Post</string>
-
+    <string name="select_course">Select a course</string>
+    <string name="post_anonymously">Post anonymously</string>
     <string name="ed_post_published_title">Posted to Ed</string>
     <string name="ed_post_published_subtitle">Your question was published.</string>
     <string name="ed_post_cancelled_title">Post cancelled</string>

--- a/app/src/test/java/com/android/sample/home/EdPostRemoteDataSourceTest.kt
+++ b/app/src/test/java/com/android/sample/home/EdPostRemoteDataSourceTest.kt
@@ -22,7 +22,7 @@ import org.mockito.kotlin.verify
 class EdPostRemoteDataSourceTest {
 
   @Test
-  fun publish_parses_camelCase_ids_and_sends_default_course() = runTest {
+  fun publish_parses_camelCase_ids_and_sends_courseId_and_isAnonymous() = runTest {
     val callableResult =
         mock<HttpsCallableResult> {
           on { getData() } doReturn
@@ -42,17 +42,75 @@ class EdPostRemoteDataSourceTest {
         }
 
     val dataSource = EdPostRemoteDataSource(functions)
-    val result = dataSource.publish("T", "B")
+    val result = dataSource.publish("T", "B", 2000L, true)
 
     // ids parsed
     assertEquals(10L, result.threadId)
     assertEquals(1153L, result.courseId)
     assertEquals(7L, result.threadNumber)
 
-    // payload contains default courseId
+    // payload contains courseId and isAnonymous
     val captor = argumentCaptor<Map<String, Any>>()
     verify(callableRef).call(captor.capture())
-    assertEquals(1153L, captor.firstValue["courseId"])
+    assertEquals(2000L, captor.firstValue["courseId"])
+    assertEquals(true, captor.firstValue["isAnonymous"])
+  }
+
+  @Test
+  fun publish_defaults_isAnonymous_to_false() = runTest {
+    val callableResult =
+        mock<HttpsCallableResult> {
+          on { getData() } doReturn
+              mapOf(
+                  "threadId" to 10,
+                  "courseId" to 1153,
+                  "threadNumber" to 7,
+              )
+        }
+    val callableRef =
+        mock<HttpsCallableReference> {
+          on { call(any<Map<String, Any>>()) } doReturn Tasks.forResult(callableResult)
+        }
+    val functions =
+        mock<FirebaseFunctions> {
+          on { getHttpsCallable("edConnectorPostFn") } doReturn callableRef
+        }
+
+    val dataSource = EdPostRemoteDataSource(functions)
+    dataSource.publish("T", "B", 2000L)
+
+    val captor = argumentCaptor<Map<String, Any>>()
+    verify(callableRef).call(captor.capture())
+    assertEquals(false, captor.firstValue["isAnonymous"])
+  }
+
+  @Test
+  fun publish_sends_null_courseId_when_not_provided() = runTest {
+    val callableResult =
+        mock<HttpsCallableResult> {
+          on { getData() } doReturn
+              mapOf(
+                  "threadId" to 10,
+                  "courseId" to 1153,
+                  "threadNumber" to 7,
+              )
+        }
+    val callableRef =
+        mock<HttpsCallableReference> {
+          on { call(any<Map<String, Any>>()) } doReturn Tasks.forResult(callableResult)
+        }
+    val functions =
+        mock<FirebaseFunctions> {
+          on { getHttpsCallable("edConnectorPostFn") } doReturn callableRef
+        }
+
+    val dataSource = EdPostRemoteDataSource(functions)
+    dataSource.publish("T", "B")
+
+    val captor = argumentCaptor<Map<String, Any>>()
+    verify(callableRef).call(captor.capture())
+    assertNull(captor.firstValue["courseId"])
+    assertEquals(false, captor.firstValue["isAnonymous"])
   }
 
   @Test
@@ -224,5 +282,87 @@ class EdPostRemoteDataSourceTest {
     val result = EdPostRemoteDataSource(functions).fetchPosts("test")
 
     assertEquals(42, result.filters.limit)
+  }
+
+  @Test
+  fun getCourses_parses_courses_correctly() = runTest {
+    val callableResult =
+        mock<HttpsCallableResult> {
+          on { getData() } doReturn
+              mapOf(
+                  "courses" to
+                      listOf(
+                          mapOf("id" to 1, "code" to "CS-101", "name" to "Intro CS"),
+                          mapOf("id" to 2, "code" to null, "name" to "No Code Course"),
+                          mapOf("id" to 3, "code" to "MATH-200", "name" to "Calculus")))
+        }
+    val callableRef =
+        mock<HttpsCallableReference> {
+          on { call(any<Map<String, Any>>()) } doReturn Tasks.forResult(callableResult)
+        }
+    val functions =
+        mock<FirebaseFunctions> {
+          on { getHttpsCallable("edConnectorGetCoursesFn") } doReturn callableRef
+        }
+
+    val dataSource = EdPostRemoteDataSource(functions)
+    val result = dataSource.getCourses()
+
+    assertEquals(3, result.courses.size)
+    assertEquals(1L, result.courses[0].id)
+    assertEquals("CS-101", result.courses[0].code)
+    assertEquals("Intro CS", result.courses[0].name)
+    assertEquals(2L, result.courses[1].id)
+    assertNull(result.courses[1].code)
+    assertEquals("No Code Course", result.courses[1].name)
+  }
+
+  @Test
+  fun getCourses_handles_empty_courses_list() = runTest {
+    val callableResult =
+        mock<HttpsCallableResult> { on { getData() } doReturn mapOf("courses" to emptyList<Any>()) }
+    val callableRef =
+        mock<HttpsCallableReference> {
+          on { call(any<Map<String, Any>>()) } doReturn Tasks.forResult(callableResult)
+        }
+    val functions =
+        mock<FirebaseFunctions> {
+          on { getHttpsCallable("edConnectorGetCoursesFn") } doReturn callableRef
+        }
+
+    val dataSource = EdPostRemoteDataSource(functions)
+    val result = dataSource.getCourses()
+
+    assertTrue(result.courses.isEmpty())
+  }
+
+  @Test
+  fun getCourses_handles_invalid_course_data() = runTest {
+    val callableResult =
+        mock<HttpsCallableResult> {
+          on { getData() } doReturn
+              mapOf(
+                  "courses" to
+                      listOf(
+                          mapOf("id" to 1, "code" to "CS-101", "name" to "Valid"),
+                          "invalid", // Not a map
+                          mapOf<String, Any?>(), // Empty map - should be filtered
+                          mapOf("id" to "not-a-number"))) // Invalid id
+        }
+    val callableRef =
+        mock<HttpsCallableReference> {
+          on { call(any<Map<String, Any>>()) } doReturn Tasks.forResult(callableResult)
+        }
+    val functions =
+        mock<FirebaseFunctions> {
+          on { getHttpsCallable("edConnectorGetCoursesFn") } doReturn callableRef
+        }
+
+    val dataSource = EdPostRemoteDataSource(functions)
+    val result = dataSource.getCourses()
+
+    // Only valid courses should be parsed
+    assertTrue(result.courses.size >= 1)
+    assertEquals("CS-101", result.courses.find { it.code == "CS-101" }?.code)
   }
 }

--- a/app/src/test/java/com/android/sample/home/EdPostRemoteDataSourceTest.kt
+++ b/app/src/test/java/com/android/sample/home/EdPostRemoteDataSourceTest.kt
@@ -85,7 +85,7 @@ class EdPostRemoteDataSourceTest {
   }
 
   @Test
-  fun publish_sends_null_courseId_when_not_provided() = runTest {
+  fun publish_omits_courseId_when_not_provided() = runTest {
     val callableResult =
         mock<HttpsCallableResult> {
           on { getData() } doReturn
@@ -109,7 +109,10 @@ class EdPostRemoteDataSourceTest {
 
     val captor = argumentCaptor<Map<String, Any>>()
     verify(callableRef).call(captor.capture())
-    assertNull(captor.firstValue["courseId"])
+    // Verify that courseId key is omitted entirely (not present in the map)
+    assertFalse(
+        "courseId should be omitted from payload when not provided",
+        captor.firstValue.containsKey("courseId"))
     assertEquals(false, captor.firstValue["isAnonymous"])
   }
 

--- a/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
@@ -1244,7 +1244,9 @@ class HomeScreenComposeInteractionsTest {
           edCourses = listOf(testCourse),
           pendingAction =
               com.android.sample.home.PendingAction.PostOnEd(
-                  draftTitle = "Original Title", draftBody = "Original Body", selectedCourseId = 1153L))
+                  draftTitle = "Original Title",
+                  draftBody = "Original Body",
+                  selectedCourseId = 1153L))
     }
 
     composeRule.setContent { HomeScreen(viewModel = viewModel) }
@@ -1410,7 +1412,9 @@ class HomeScreenComposeInteractionsTest {
           edCourses = listOf(testCourse),
           pendingAction =
               com.android.sample.home.PendingAction.PostOnEd(
-                  draftTitle = "Initial Title", draftBody = "Initial Body", selectedCourseId = 1153L))
+                  draftTitle = "Initial Title",
+                  draftBody = "Initial Body",
+                  selectedCourseId = 1153L))
     }
 
     composeRule.setContent { HomeScreen(viewModel = viewModel) }

--- a/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
@@ -1232,7 +1232,8 @@ class HomeScreenComposeInteractionsTest {
   @Test
   fun HomeScreen_edPostConfirmationModal_publish_calls_viewModel_publishEdPost() {
     val dataSource = mockk<EdPostRemoteDataSource>()
-    coEvery { dataSource.publish(any(), any()) } returns EdPostPublishResult(1, 1153, 10)
+    coEvery { dataSource.publish(any(), any(), any(), any()) } returns
+        EdPostPublishResult(1, 1153, 10)
     val viewModel = HomeViewModel(edPostDataSourceOverride = dataSource)
     // Add a message so LazyColumn is displayed (modal is in LazyColumn)
     val userMsg = ChatUIModel(id = "msg-1", text = "Hello", timestamp = 0L, type = ChatType.USER)
@@ -1395,7 +1396,8 @@ class HomeScreenComposeInteractionsTest {
   @Test
   fun HomeScreen_edPostConfirmationModal_allows_editing_before_publish() {
     val dataSource = mockk<EdPostRemoteDataSource>()
-    coEvery { dataSource.publish(any(), any()) } returns EdPostPublishResult(2, 1153, 11)
+    coEvery { dataSource.publish(any(), any(), any(), any()) } returns
+        EdPostPublishResult(2, 1153, 11)
     val viewModel = HomeViewModel(edPostDataSourceOverride = dataSource)
     // Add a message so LazyColumn is displayed (modal is in LazyColumn)
     val userMsg = ChatUIModel(id = "msg-1", text = "Hello", timestamp = 0L, type = ChatType.USER)

--- a/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeScreenTest.kt
@@ -1237,12 +1237,14 @@ class HomeScreenComposeInteractionsTest {
     val viewModel = HomeViewModel(edPostDataSourceOverride = dataSource)
     // Add a message so LazyColumn is displayed (modal is in LazyColumn)
     val userMsg = ChatUIModel(id = "msg-1", text = "Hello", timestamp = 0L, type = ChatType.USER)
+    val testCourse = EdCourse(id = 1153L, code = "CS-101", name = "Intro to CS")
     viewModel.editState {
       it.copy(
           messages = listOf(userMsg),
+          edCourses = listOf(testCourse),
           pendingAction =
               com.android.sample.home.PendingAction.PostOnEd(
-                  draftTitle = "Original Title", draftBody = "Original Body"))
+                  draftTitle = "Original Title", draftBody = "Original Body", selectedCourseId = 1153L))
     }
 
     composeRule.setContent { HomeScreen(viewModel = viewModel) }
@@ -1401,12 +1403,14 @@ class HomeScreenComposeInteractionsTest {
     val viewModel = HomeViewModel(edPostDataSourceOverride = dataSource)
     // Add a message so LazyColumn is displayed (modal is in LazyColumn)
     val userMsg = ChatUIModel(id = "msg-1", text = "Hello", timestamp = 0L, type = ChatType.USER)
+    val testCourse = EdCourse(id = 1153L, code = "CS-101", name = "Intro to CS")
     viewModel.editState {
       it.copy(
           messages = listOf(userMsg),
+          edCourses = listOf(testCourse),
           pendingAction =
               com.android.sample.home.PendingAction.PostOnEd(
-                  draftTitle = "Initial Title", draftBody = "Initial Body"))
+                  draftTitle = "Initial Title", draftBody = "Initial Body", selectedCourseId = 1153L))
     }
 
     composeRule.setContent { HomeScreen(viewModel = viewModel) }

--- a/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
@@ -167,12 +167,18 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
     // Set an existing conversation ID BEFORE going offline
     vm.editState { it.copy(currentConversationId = "existing-conv-123") }
 
-    // Go offline
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("Test question")
 
@@ -184,14 +190,14 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(500)
     advanceUntilIdle()
 
-    // Verify that the messages were added (cached response was used)
-    val messages = vm.uiState.first().messages
+    // Verify that the messages were added (cached response was used) - use value instead of first()
+    val messages = vm.uiState.value.messages
     assertTrue(
-        "Should have AI message with cached response",
+        "Should have AI message with cached response, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.AI && it.text.contains("Cached response") })
 
     // Verify repo.appendMessage was called to persist the cached response
-    verify(repo, atLeastOnce())
+    verify(repo, timeout(1000).atLeastOnce())
         .appendMessage(eq("existing-conv-123"), eq("assistant"), eq(cachedResponse), anyOrNull())
   }
 
@@ -227,11 +233,18 @@ class HomeViewModelOfflineCacheCoverageTest {
 
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
+
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
     vm.editState { it.copy(currentConversationId = "conv-123") }
 
-    // Go offline
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
@@ -241,8 +254,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(300)
     advanceUntilIdle()
 
-    // Should still show cached response despite persist failure
-    val messages = vm.uiState.first().messages
+    // Should still show cached response despite persist failure - use value instead of first()
+    val messages = vm.uiState.value.messages
     assertTrue(
         "Should have AI message with cached response, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.AI && it.text.contains("Cached response") })
@@ -257,12 +270,19 @@ class HomeViewModelOfflineCacheCoverageTest {
 
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
+
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
     // Avoid messagesFlow() wiping local messages by keeping a non-null conversation id
     vm.editState { it.copy(currentConversationId = "conv-offline") }
 
-    // Go offline
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
@@ -272,8 +292,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(200)
     advanceUntilIdle()
 
-    // Verify error message is shown
-    val messages = vm.uiState.first().messages
+    // Verify error message is shown - use value instead of first()
+    val messages = vm.uiState.value.messages
     assertTrue(
         "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.USER })
@@ -311,16 +331,27 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Go offline
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Verify send flow completed gracefully (no crash) and streaming stopped
-    val state = vm.uiState.first()
+    // Additional wait to ensure error handling completes
+    delay(200)
+    advanceUntilIdle()
+
+    // Verify send flow completed gracefully (no crash) and streaming stopped - use value instead of
+    // first()
+    val state = vm.uiState.value
     assertFalse("Should stop sending after cache exception", state.isSending)
   }
 
@@ -335,16 +366,27 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Go offline
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Verify send flow completed gracefully (no crash) and streaming stopped
-    val state = vm.uiState.first()
+    // Additional wait to ensure error handling completes
+    delay(200)
+    advanceUntilIdle()
+
+    // Verify send flow completed gracefully (no crash) and streaming stopped - use value instead of
+    // first()
+    val state = vm.uiState.value
     assertFalse("Should stop sending after cache exception", state.isSending)
   }
 
@@ -356,17 +398,30 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Go offline
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
+    // Go offline and wait for state to update
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    val messages = vm.uiState.first().messages
+    // Additional wait to ensure error handling completes
+    delay(200)
+    advanceUntilIdle()
+
+    // Use value instead of first()
+    val messages = vm.uiState.value.messages
     val aiMessage = messages.find { it.type == ChatType.AI }
-    assertNotNull("Should have AI message", aiMessage)
+    assertNotNull(
+        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        aiMessage)
   }
 
   // ==================== OFFLINE CHECK VIA isCurrentlyOnline ====================
@@ -379,20 +434,30 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
+    // Wait for ViewModel initialization
+    advanceUntilIdle()
+    delay(50)
+
     // State says online but monitor says offline
     vm.editState { it.copy(isOffline = false) }
     networkMonitor.setOnline(false)
+    advanceUntilIdle()
     delay(100)
+    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Should have detected offline via isCurrentlyOnline() and used cache
-    verify(cacheRepo).getCachedResponse("Test question", true)
+    // Additional wait to ensure state updates
+    delay(200)
+    advanceUntilIdle()
 
-    // Should update state to reflect offline
-    assertTrue("Should detect offline", vm.uiState.first().isOffline)
+    // Should have detected offline via isCurrentlyOnline() and used cache
+    verify(cacheRepo, timeout(1000)).getCachedResponse("Test question", true)
+
+    // Should update state to reflect offline - use value instead of first()
+    assertTrue("Should detect offline", vm.uiState.value.isOffline)
   }
 
   @Test
@@ -438,8 +503,12 @@ class HomeViewModelOfflineCacheCoverageTest {
     verify(cacheRepo, never()).getCachedResponse(any(), any())
 
     // Verify LLM path was taken: streaming finished and an AI message exists
-    val messages = vm.uiState.first().messages
-    assertTrue(messages.any { it.type == ChatType.AI })
+    delay(200)
+    advanceUntilIdle()
+    val messages = vm.uiState.value.messages
+    assertTrue(
+        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        messages.any { it.type == ChatType.AI })
     assertFalse("streaming should be complete", vm.uiState.value.isSending)
   }
 
@@ -467,10 +536,14 @@ class HomeViewModelOfflineCacheCoverageTest {
     // Verify cache was NOT queried with preferCache=true (offline mode)
     verify(cacheRepo, never()).getCachedResponse(any(), eq(true))
 
-    // Verify user message was sent (conversation was created)
-    val messages = vm.uiState.first().messages
+    // Additional wait to ensure state updates
+    delay(200)
+    advanceUntilIdle()
+
+    // Verify user message was sent (conversation was created) - use value instead of first()
+    val messages = vm.uiState.value.messages
     assertTrue(
-        "Should have user message",
+        "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.USER && it.text == "Test question" })
   }
 
@@ -496,10 +569,12 @@ class HomeViewModelOfflineCacheCoverageTest {
     vm.awaitStreamingCompletion()
 
     // Verify parameter was used, not draft
-    verify(cacheRepo).getCachedResponse(eq("parameter message"), eq(true))
-    val messages = vm.uiState.first().messages
+    verify(cacheRepo, timeout(1000)).getCachedResponse(eq("parameter message"), eq(true))
+    delay(200)
+    advanceUntilIdle()
+    val messages = vm.uiState.value.messages
     assertTrue(
-        "Should have user message with parameter",
+        "Should have user message with parameter, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.USER && it.text == "parameter message" })
   }
 
@@ -562,8 +637,12 @@ class HomeViewModelOfflineCacheCoverageTest {
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Verify sending completes (isSending should be false)
-    val state = vm.uiState.first()
+    // Additional wait to ensure state updates
+    delay(200)
+    advanceUntilIdle()
+
+    // Verify sending completes (isSending should be false) - use value instead of first()
+    val state = vm.uiState.value
     assertFalse("isSending should be false after completion", state.isSending)
   }
 
@@ -582,9 +661,15 @@ class HomeViewModelOfflineCacheCoverageTest {
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Verify cached response is in messages
-    val messages = vm.uiState.first().messages
-    assertTrue("Should have AI message", messages.any { it.type == ChatType.AI })
+    // Additional wait to ensure state updates
+    delay(200)
+    advanceUntilIdle()
+
+    // Verify cached response is in messages - use value instead of first()
+    val messages = vm.uiState.value.messages
+    assertTrue(
+        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        messages.any { it.type == ChatType.AI })
   }
 
   // ==================== CONCURRENT SEND PROTECTION ====================
@@ -728,10 +813,16 @@ class HomeViewModelOfflineCacheCoverageTest {
     vm.awaitStreamingCompletion()
 
     // Should have both user and AI messages (AI message will be error)
-    val messages = vm.uiState.first().messages
+    // Additional wait to ensure state updates
+    delay(200)
+    advanceUntilIdle()
+
+    val messages = vm.uiState.value.messages
     assertTrue(
-        "Should have user message",
+        "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.USER && it.text == "Test question" })
-    assertTrue("Should have AI message", messages.any { it.type == ChatType.AI })
+    assertTrue(
+        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        messages.any { it.type == ChatType.AI })
   }
 }

--- a/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
@@ -167,18 +167,12 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
     // Set an existing conversation ID BEFORE going offline
     vm.editState { it.copy(currentConversationId = "existing-conv-123") }
 
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("Test question")
 
@@ -190,14 +184,14 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(500)
     advanceUntilIdle()
 
-    // Verify that the messages were added (cached response was used) - use value instead of first()
-    val messages = vm.uiState.value.messages
+    // Verify that the messages were added (cached response was used)
+    val messages = vm.uiState.first().messages
     assertTrue(
-        "Should have AI message with cached response, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have AI message with cached response",
         messages.any { it.type == ChatType.AI && it.text.contains("Cached response") })
 
     // Verify repo.appendMessage was called to persist the cached response
-    verify(repo, timeout(1000).atLeastOnce())
+    verify(repo, atLeastOnce())
         .appendMessage(eq("existing-conv-123"), eq("assistant"), eq(cachedResponse), anyOrNull())
   }
 
@@ -233,18 +227,11 @@ class HomeViewModelOfflineCacheCoverageTest {
 
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
-
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
     vm.editState { it.copy(currentConversationId = "conv-123") }
 
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
@@ -254,8 +241,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(300)
     advanceUntilIdle()
 
-    // Should still show cached response despite persist failure - use value instead of first()
-    val messages = vm.uiState.value.messages
+    // Should still show cached response despite persist failure
+    val messages = vm.uiState.first().messages
     assertTrue(
         "Should have AI message with cached response, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.AI && it.text.contains("Cached response") })
@@ -270,19 +257,12 @@ class HomeViewModelOfflineCacheCoverageTest {
 
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
-
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
     // Avoid messagesFlow() wiping local messages by keeping a non-null conversation id
     vm.editState { it.copy(currentConversationId = "conv-offline") }
 
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
@@ -292,8 +272,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     delay(200)
     advanceUntilIdle()
 
-    // Verify error message is shown - use value instead of first()
-    val messages = vm.uiState.value.messages
+    // Verify error message is shown
+    val messages = vm.uiState.first().messages
     assertTrue(
         "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
         messages.any { it.type == ChatType.USER })
@@ -331,27 +311,16 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure error handling completes
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify send flow completed gracefully (no crash) and streaming stopped - use value instead of
-    // first()
-    val state = vm.uiState.value
+    // Verify send flow completed gracefully (no crash) and streaming stopped
+    val state = vm.uiState.first()
     assertFalse("Should stop sending after cache exception", state.isSending)
   }
 
@@ -366,27 +335,16 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("What is EPFL?")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure error handling completes
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify send flow completed gracefully (no crash) and streaming stopped - use value instead of
-    // first()
-    val state = vm.uiState.value
+    // Verify send flow completed gracefully (no crash) and streaming stopped
+    val state = vm.uiState.first()
     assertFalse("Should stop sending after cache exception", state.isSending)
   }
 
@@ -398,30 +356,17 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure error handling completes
-    delay(200)
-    advanceUntilIdle()
-
-    // Use value instead of first()
-    val messages = vm.uiState.value.messages
+    val messages = vm.uiState.first().messages
     val aiMessage = messages.find { it.type == ChatType.AI }
-    assertNotNull(
-        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
-        aiMessage)
+    assertNotNull("Should have AI message", aiMessage)
   }
 
   // ==================== OFFLINE CHECK VIA isCurrentlyOnline ====================
@@ -434,30 +379,20 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization
-    advanceUntilIdle()
-    delay(50)
-
     // State says online but monitor says offline
     vm.editState { it.copy(isOffline = false) }
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
 
     vm.sendMessage("Test question")
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure state updates
-    delay(200)
-    advanceUntilIdle()
-
     // Should have detected offline via isCurrentlyOnline() and used cache
-    verify(cacheRepo, timeout(1000)).getCachedResponse("Test question", true)
+    verify(cacheRepo).getCachedResponse("Test question", true)
 
-    // Should update state to reflect offline - use value instead of first()
-    assertTrue("Should detect offline", vm.uiState.value.isOffline)
+    // Should update state to reflect offline
+    assertTrue("Should detect offline", vm.uiState.first().isOffline)
   }
 
   @Test
@@ -503,12 +438,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     verify(cacheRepo, never()).getCachedResponse(any(), any())
 
     // Verify LLM path was taken: streaming finished and an AI message exists
-    delay(200)
-    advanceUntilIdle()
-    val messages = vm.uiState.value.messages
-    assertTrue(
-        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
-        messages.any { it.type == ChatType.AI })
+    val messages = vm.uiState.first().messages
+    assertTrue(messages.any { it.type == ChatType.AI })
     assertFalse("streaming should be complete", vm.uiState.value.isSending)
   }
 
@@ -536,14 +467,10 @@ class HomeViewModelOfflineCacheCoverageTest {
     // Verify cache was NOT queried with preferCache=true (offline mode)
     verify(cacheRepo, never()).getCachedResponse(any(), eq(true))
 
-    // Additional wait to ensure state updates
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify user message was sent (conversation was created) - use value instead of first()
-    val messages = vm.uiState.value.messages
+    // Verify user message was sent (conversation was created)
+    val messages = vm.uiState.first().messages
     assertTrue(
-        "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have user message",
         messages.any { it.type == ChatType.USER && it.text == "Test question" })
   }
 
@@ -569,12 +496,10 @@ class HomeViewModelOfflineCacheCoverageTest {
     vm.awaitStreamingCompletion()
 
     // Verify parameter was used, not draft
-    verify(cacheRepo, timeout(1000)).getCachedResponse(eq("parameter message"), eq(true))
-    delay(200)
-    advanceUntilIdle()
-    val messages = vm.uiState.value.messages
+    verify(cacheRepo).getCachedResponse(eq("parameter message"), eq(true))
+    val messages = vm.uiState.first().messages
     assertTrue(
-        "Should have user message with parameter, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have user message with parameter",
         messages.any { it.type == ChatType.USER && it.text == "parameter message" })
   }
 
@@ -637,12 +562,8 @@ class HomeViewModelOfflineCacheCoverageTest {
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure state updates
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify sending completes (isSending should be false) - use value instead of first()
-    val state = vm.uiState.value
+    // Verify sending completes (isSending should be false)
+    val state = vm.uiState.first()
     assertFalse("isSending should be false after completion", state.isSending)
   }
 
@@ -661,15 +582,9 @@ class HomeViewModelOfflineCacheCoverageTest {
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure state updates
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify cached response is in messages - use value instead of first()
-    val messages = vm.uiState.value.messages
-    assertTrue(
-        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
-        messages.any { it.type == ChatType.AI })
+    // Verify cached response is in messages
+    val messages = vm.uiState.first().messages
+    assertTrue("Should have AI message", messages.any { it.type == ChatType.AI })
   }
 
   // ==================== CONCURRENT SEND PROTECTION ====================
@@ -813,16 +728,10 @@ class HomeViewModelOfflineCacheCoverageTest {
     vm.awaitStreamingCompletion()
 
     // Should have both user and AI messages (AI message will be error)
-    // Additional wait to ensure state updates
-    delay(200)
-    advanceUntilIdle()
-
-    val messages = vm.uiState.value.messages
+    val messages = vm.uiState.first().messages
     assertTrue(
-        "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have user message",
         messages.any { it.type == ChatType.USER && it.text == "Test question" })
-    assertTrue(
-        "Should have AI message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
-        messages.any { it.type == ChatType.AI })
+    assertTrue("Should have AI message", messages.any { it.type == ChatType.AI })
   }
 }

--- a/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeViewModelOfflineCacheCoverageTest.kt
@@ -28,7 +28,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
-import org.mockito.kotlin.timeout
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -115,42 +114,26 @@ class HomeViewModelOfflineCacheCoverageTest {
     val vm =
         HomeViewModel(llmClient, auth, repo, networkMonitor = networkMonitor, cacheRepo = cacheRepo)
 
-    // Wait for ViewModel initialization to complete
-    advanceUntilIdle()
-    delay(50)
-
-    // Go offline and wait for state to update
+    // Go offline
     networkMonitor.setOnline(false)
-    advanceUntilIdle()
     delay(100)
-    advanceUntilIdle()
-
-    // Verify we're offline before sending
-    assertTrue(
-        "Should be offline", vm.uiState.value.isOffline || !networkMonitor.isCurrentlyOnline())
 
     vm.updateMessageDraft("What is EPFL?")
     vm.sendMessage()
-
-    // Wait for all coroutines to complete
     advanceUntilIdle()
     vm.awaitStreamingCompletion()
 
-    // Additional wait to ensure simulateStreamingFromText completes
-    delay(200)
-    advanceUntilIdle()
-
-    // Verify cached response was used - use value instead of first() to get current state
-    val messages = vm.uiState.value.messages
+    // Verify cached response was used
+    val messages = vm.uiState.first().messages
     assertTrue(
-        "Should have user message, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have user message",
         messages.any { it.type == ChatType.USER && it.text == "What is EPFL?" })
     assertTrue(
-        "Should have AI message with cached response, got ${messages.size} messages: ${messages.map { "${it.type}: ${it.text.take(50)}" }}",
+        "Should have AI message with cached response",
         messages.any { it.type == ChatType.AI && it.text.contains("cached response") })
 
     // Verify cache was queried with preferCache=true
-    verify(cacheRepo, timeout(1000)).getCachedResponse("What is EPFL?", true)
+    verify(cacheRepo).getCachedResponse("What is EPFL?", true)
   }
 
   @Test

--- a/app/src/test/java/com/android/sample/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeViewModelTest.kt
@@ -43,9 +43,11 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.timeout
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -287,7 +289,8 @@ class HomeViewModelTest {
       runTest(testDispatcher) {
         val dataSource = mock<EdPostRemoteDataSource>()
         runBlocking {
-          whenever(dataSource.publish(any(), any())).thenReturn(EdPostPublishResult(1, 1, 1))
+          whenever(dataSource.publish(any(), any(), anyOrNull(), any()))
+              .thenReturn(EdPostPublishResult(1, 1, 1))
         }
         val viewModel =
             HomeViewModel(
@@ -355,7 +358,8 @@ class HomeViewModelTest {
       runTest(testDispatcher) {
         val dataSource = mock<EdPostRemoteDataSource>()
         runBlocking {
-          whenever(dataSource.publish(any(), any())).thenReturn(EdPostPublishResult(2, 1153, 20))
+          whenever(dataSource.publish(any(), any(), anyOrNull(), any()))
+              .thenReturn(EdPostPublishResult(2, 1153, 20))
         }
         val viewModel =
             HomeViewModel(
@@ -522,7 +526,8 @@ class HomeViewModelTest {
       runTest(testDispatcher) {
         val dataSource = mock<EdPostRemoteDataSource>()
         runBlocking {
-          whenever(dataSource.publish(any(), any())).thenReturn(EdPostPublishResult(1, 1, 1))
+          whenever(dataSource.publish(any(), any(), anyOrNull(), any()))
+              .thenReturn(EdPostPublishResult(1, 1, 1))
         }
         val viewModel =
             HomeViewModel(
@@ -562,7 +567,8 @@ class HomeViewModelTest {
       runTest(testDispatcher) {
         val dataSource = mock<EdPostRemoteDataSource>()
         runBlocking {
-          whenever(dataSource.publish(any(), any())).thenReturn(EdPostPublishResult(99, 1153, 12))
+          whenever(dataSource.publish(any(), any(), anyOrNull(), any()))
+              .thenReturn(EdPostPublishResult(99, 1153, 12))
         }
         val viewModel =
             HomeViewModel(
@@ -583,7 +589,8 @@ class HomeViewModelTest {
       runTest(testDispatcher) {
         val dataSource = mock<EdPostRemoteDataSource>()
         runBlocking {
-          whenever(dataSource.publish(any(), any())).thenThrow(RuntimeException("backend down"))
+          whenever(dataSource.publish(any(), any(), anyOrNull(), any()))
+              .thenThrow(RuntimeException("backend down"))
         }
         val viewModel =
             HomeViewModel(
@@ -597,6 +604,104 @@ class HomeViewModelTest {
         assertTrue(state.edPostResult is EdPostResult.Failed)
         assertTrue(state.edPostCards.isEmpty())
         assertFalse(state.isPostingToEd)
+      }
+
+  @Test
+  fun publishEdPost_with_courseId_and_isAnonymous() =
+      runTest(testDispatcher) {
+        val dataSource = mock<EdPostRemoteDataSource>()
+        runBlocking {
+          whenever(dataSource.publish(eq("Title"), eq("Body"), eq(2000L), eq(true)))
+              .thenReturn(EdPostPublishResult(99, 2000, 12))
+        }
+        val viewModel =
+            HomeViewModel(
+                profileRepository = FakeProfileRepository(), edPostDataSourceOverride = dataSource)
+
+        viewModel.publishEdPost("Title", "Body", 2000L, true)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.edPostResult is EdPostResult.Published)
+        assertNull(state.pendingAction)
+        assertFalse(state.isPostingToEd)
+      }
+
+  @Test
+  fun loadEdCourses_loads_and_stores_courses() =
+      runTest(testDispatcher) {
+        val dataSource = mock<EdPostRemoteDataSource>()
+        val coursesResult =
+            EdCoursesResult(
+                listOf(EdCourse(1L, "CS-101", "Intro CS"), EdCourse(2L, "MATH-200", "Calculus")))
+        runBlocking { whenever(dataSource.getCourses()).thenReturn(coursesResult) }
+        val viewModel =
+            HomeViewModel(
+                profileRepository = FakeProfileRepository(), edPostDataSourceOverride = dataSource)
+
+        viewModel.loadEdCourses()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.edCourses.size)
+        assertEquals("CS-101", state.edCourses[0].code)
+        assertEquals("Intro CS", state.edCourses[0].name)
+        assertFalse(state.isLoadingEdCourses)
+      }
+
+  @Test
+  fun loadEdCourses_handles_error_gracefully() =
+      runTest(testDispatcher) {
+        val dataSource = mock<EdPostRemoteDataSource>()
+        runBlocking {
+          whenever(dataSource.getCourses()).thenThrow(RuntimeException("Network error"))
+        }
+        val viewModel =
+            HomeViewModel(
+                profileRepository = FakeProfileRepository(), edPostDataSourceOverride = dataSource)
+
+        viewModel.loadEdCourses()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.edCourses.isEmpty())
+        assertFalse(state.isLoadingEdCourses)
+      }
+
+  @Test
+  fun loadEdCourses_prevents_multiple_concurrent_loads() =
+      runTest(testDispatcher) {
+        val dataSource = mock<EdPostRemoteDataSource>()
+        val coursesResult = EdCoursesResult(listOf(EdCourse(1L, "CS-101", "Intro CS")))
+        runBlocking { whenever(dataSource.getCourses()).thenReturn(coursesResult) }
+        val viewModel =
+            HomeViewModel(
+                profileRepository = FakeProfileRepository(), edPostDataSourceOverride = dataSource)
+
+        viewModel.loadEdCourses()
+        viewModel.loadEdCourses() // Second call should be ignored
+        advanceUntilIdle()
+
+        verify(dataSource, times(1)).getCourses()
+      }
+
+  @Test
+  fun publishEdPost_with_default_parameters() =
+      runTest(testDispatcher) {
+        val dataSource = mock<EdPostRemoteDataSource>()
+        runBlocking {
+          whenever(dataSource.publish(eq("Title"), eq("Body"), eq(null), eq(false)))
+              .thenReturn(EdPostPublishResult(99, 1153, 12))
+        }
+        val viewModel =
+            HomeViewModel(
+                profileRepository = FakeProfileRepository(), edPostDataSourceOverride = dataSource)
+
+        viewModel.publishEdPost("Title", "Body")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.edPostResult is EdPostResult.Published)
       }
 
   @Test

--- a/app/src/test/java/com/android/sample/llm/FakeLlmClient.kt
+++ b/app/src/test/java/com/android/sample/llm/FakeLlmClient.kt
@@ -27,7 +27,8 @@ class FakeLlmClient : LlmClient {
       reply: String,
       intent: String,
       formattedQuestion: String,
-      formattedTitle: String
+      formattedTitle: String,
+      suggestedCourseId: Long? = null
   ) {
     nextReply = reply
     nextEdIntent =
@@ -35,7 +36,8 @@ class FakeLlmClient : LlmClient {
             detected = true,
             intent = intent,
             formattedQuestion = formattedQuestion,
-            formattedTitle = formattedTitle)
+            formattedTitle = formattedTitle,
+            suggestedCourseId = suggestedCourseId)
   }
 
   /** Configure the fake to return an ED fetch intent response */

--- a/app/src/test/java/com/android/sample/llm/FirebaseFunctionsLlmClientTest.kt
+++ b/app/src/test/java/com/android/sample/llm/FirebaseFunctionsLlmClientTest.kt
@@ -333,4 +333,174 @@ class FirebaseFunctionsLlmClientTest {
     assertTrue(result.edFetchIntent.detected)
     assertNull(result.edFetchIntent.query)
   }
+
+  // ==================== ED SUGGESTED COURSE ID TESTS ====================
+
+  @Test
+  fun generateReply_parses_ed_suggested_course_id_as_number() = runTest {
+    val reply = "I detected you want to post on ED"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to 12345))
+
+    val result = client.generateReply("poste sur ed")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertEquals(12345L, result.edIntent.suggestedCourseId)
+  }
+
+  @Test
+  fun generateReply_parses_ed_suggested_course_id_as_long() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to 67890L))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertEquals(67890L, result.edIntent.suggestedCourseId)
+  }
+
+  @Test
+  fun generateReply_handles_ed_suggested_course_id_missing() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf("reply" to reply, "ed_intent_detected" to true, "ed_intent" to "post_question"))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertNull(result.edIntent.suggestedCourseId)
+  }
+
+  @Test
+  fun generateReply_handles_ed_suggested_course_id_null() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to null))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertNull(result.edIntent.suggestedCourseId)
+  }
+
+  @Test
+  fun generateReply_rejects_ed_suggested_course_id_negative() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to -1))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertNull(result.edIntent.suggestedCourseId) // Negative values should be rejected
+  }
+
+  @Test
+  fun generateReply_handles_ed_suggested_course_id_invalid_type() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to "not-a-number"))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertNull(result.edIntent.suggestedCourseId) // Invalid type should be rejected
+  }
+
+  @Test
+  fun generateReply_complete_ed_response_with_suggested_course_id() = runTest {
+    val reply = "I detected you want to post on ED"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "primary_url" to "https://epfl.ch",
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_formatted_question" to
+                    "Bonjour,\n\nComment résoudre ce problème ?\n\nMerci d'avance !",
+                "ed_formatted_title" to "Question 5 Modstoch",
+                "ed_suggested_course_id" to 54321))
+
+    val result = client.generateReply("poste sur ed")
+
+    assertEquals(reply, result.reply)
+    assertEquals("https://epfl.ch", result.url)
+    assertTrue(result.edIntent.detected)
+    assertEquals("post_question", result.edIntent.intent)
+    assertEquals(
+        "Bonjour,\n\nComment résoudre ce problème ?\n\nMerci d'avance !",
+        result.edIntent.formattedQuestion)
+    assertEquals("Question 5 Modstoch", result.edIntent.formattedTitle)
+    assertEquals(54321L, result.edIntent.suggestedCourseId)
+  }
+
+  @Test
+  fun generateReply_handles_ed_suggested_course_id_zero() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to 0))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertEquals(0L, result.edIntent.suggestedCourseId) // Zero is valid
+  }
+
+  @Test
+  fun generateReply_handles_ed_suggested_course_id_large_number() = runTest {
+    val reply = "Response"
+    val client =
+        clientWithResult(
+            mapOf(
+                "reply" to reply,
+                "ed_intent_detected" to true,
+                "ed_intent" to "post_question",
+                "ed_suggested_course_id" to 999999999))
+
+    val result = client.generateReply("test")
+
+    assertEquals(reply, result.reply)
+    assertTrue(result.edIntent.detected)
+    assertEquals(999999999L, result.edIntent.suggestedCourseId)
+  }
 }

--- a/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
+++ b/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
@@ -124,4 +124,52 @@ class EdPostConfirmationModalTest {
     // We verify this by checking that the Post button is still displayed but disabled
     composeRule.onNodeWithText("Post").assertIsDisplayed()
   }
+
+  @Test
+  fun edPostConfirmationModal_shows_spinner_in_dropdown_when_isLoadingCourses_is_true() {
+    val testCourse =
+        com.android.sample.home.EdCourse(id = 1153L, code = "CS-101", name = "Intro to CS")
+
+    composeRule.setContent {
+      EdPostConfirmationModal(
+          title = "Title",
+          body = "Body",
+          courses = listOf(testCourse),
+          isLoadingCourses = true,
+          onPublish = { _, _, _, _ -> },
+          onCancel = {})
+    }
+
+    // Verify that the dropdown field is displayed
+    composeRule.onNode(hasText("Select a course", substring = true)).assertIsDisplayed()
+
+    // Verify that the dropdown is disabled when loading courses
+    // The dropdown field should be disabled
+    composeRule.onNode(hasText("Select a course", substring = true)).assertIsNotEnabled()
+
+    // Verify that a CircularProgressIndicator is shown in the trailing icon
+    // We can verify this by checking that the dropdown exists but is disabled
+    // and the text field is present (which contains the spinner)
+    composeRule.onNode(hasText("Select a course", substring = true)).assertIsDisplayed()
+  }
+
+  @Test
+  fun edPostConfirmationModal_shows_dropdown_when_courses_empty_but_isLoadingCourses_true() {
+    composeRule.setContent {
+      EdPostConfirmationModal(
+          title = "Title",
+          body = "Body",
+          courses = emptyList(),
+          isLoadingCourses = true,
+          onPublish = { _, _, _, _ -> },
+          onCancel = {})
+    }
+
+    // Verify that the dropdown is displayed even when courses list is empty
+    // but isLoadingCourses is true
+    composeRule.onNode(hasText("Select a course", substring = true)).assertIsDisplayed()
+
+    // Verify that the dropdown is disabled when loading
+    composeRule.onNode(hasText("Select a course", substring = true)).assertIsNotEnabled()
+  }
 }

--- a/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
+++ b/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
@@ -22,11 +22,15 @@ class EdPostConfirmationModalTest {
   fun EdPostConfirmationModal_displays_and_allows_editing() {
     var publishTitle = ""
     var publishBody = ""
+    val testCourse =
+        com.android.sample.home.EdCourse(id = 1153L, code = "CS-101", name = "Intro to CS")
 
     composeRule.setContent {
       EdPostConfirmationModal(
           title = "Initial Title",
           body = "Initial Body",
+          courses = listOf(testCourse),
+          selectedCourseId = 1153L,
           onPublish = { title, body, _, _ ->
             publishTitle = title
             publishBody = body

--- a/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
+++ b/app/src/test/java/com/android/sample/ui/components/EdPostConfirmationModalTest.kt
@@ -27,7 +27,7 @@ class EdPostConfirmationModalTest {
       EdPostConfirmationModal(
           title = "Initial Title",
           body = "Initial Body",
-          onPublish = { title, body ->
+          onPublish = { title, body, _, _ ->
             publishTitle = title
             publishBody = body
           },
@@ -53,7 +53,7 @@ class EdPostConfirmationModalTest {
       EdPostConfirmationModal(
           title = "Title",
           body = "Body",
-          onPublish = { _, _ -> },
+          onPublish = { _, _, _, _ -> },
           onCancel = { cancelCalled = true })
     }
 
@@ -66,7 +66,10 @@ class EdPostConfirmationModalTest {
   fun EdPostConfirmationModal_handles_backslash_n_in_title() {
     composeRule.setContent {
       EdPostConfirmationModal(
-          title = "Title\\nWith\\nNewlines", body = "Body", onPublish = { _, _ -> }, onCancel = {})
+          title = "Title\\nWith\\nNewlines",
+          body = "Body",
+          onPublish = { _, _, _, _ -> },
+          onCancel = {})
     }
 
     // The text should be displayed (the component replaces \n internally)
@@ -78,7 +81,7 @@ class EdPostConfirmationModalTest {
   fun EdPostConfirmationModal_displays_initial_title() {
     composeRule.setContent {
       EdPostConfirmationModal(
-          title = "Title 1", body = "Body", onPublish = { _, _ -> }, onCancel = {})
+          title = "Title 1", body = "Body", onPublish = { _, _, _, _ -> }, onCancel = {})
     }
 
     composeRule.onNode(hasText("Title 1")).assertIsDisplayed()
@@ -88,7 +91,7 @@ class EdPostConfirmationModalTest {
   fun EdPostConfirmationModal_displays_initial_body() {
     composeRule.setContent {
       EdPostConfirmationModal(
-          title = "Title", body = "Body 1", onPublish = { _, _ -> }, onCancel = {})
+          title = "Title", body = "Body 1", onPublish = { _, _, _, _ -> }, onCancel = {})
     }
 
     composeRule.onNode(hasText("Body 1")).assertIsDisplayed()
@@ -98,7 +101,11 @@ class EdPostConfirmationModalTest {
   fun edPostConfirmationModal_shows_loading_indicator_when_isLoading_is_true() {
     composeRule.setContent {
       EdPostConfirmationModal(
-          title = "Title", body = "Body", isLoading = true, onPublish = { _, _ -> }, onCancel = {})
+          title = "Title",
+          body = "Body",
+          isLoading = true,
+          onPublish = { _, _, _, _ -> },
+          onCancel = {})
     }
 
     // Verify that text fields are disabled when loading

--- a/functions/src/connectors/ed/EdConnectorService.ts
+++ b/functions/src/connectors/ed/EdConnectorService.ts
@@ -163,7 +163,7 @@ export class EdConnectorService {
 
     const apiToken = this.decrypt(existing.apiKeyEncrypted);
     const baseUrl = this.resolveBaseUrl(existing.baseUrl);
-    if (!params.courseId) {
+    if (params.courseId == null) {
       throw new Error("courseId is required");
     }
     const courseId = params.courseId;

--- a/functions/src/connectors/ed/EdConnectorService.ts
+++ b/functions/src/connectors/ed/EdConnectorService.ts
@@ -20,8 +20,7 @@ export class EdConnectorService {
     private readonly repo: EdConnectorRepository,
     private readonly encrypt: (plain: string) => string,
     private readonly decrypt: (cipher: string) => string,
-    private readonly defaultBaseUrl: string = "https://eu.edstem.org/api",
-    private readonly defaultCourseId: number = 1153
+    private readonly defaultBaseUrl: string = "https://eu.edstem.org/api"
   ) {}
 
   private resolveBaseUrl(baseUrl?: string): string {
@@ -150,7 +149,7 @@ export class EdConnectorService {
    */
   async postThread(
     userId: string,
-    params: { title: string; body: string; courseId?: number }
+    params: { title: string; body: string; courseId?: number; isAnonymous?: boolean }
   ): Promise<{
     threadId?: number;
     courseId?: number;
@@ -164,12 +163,16 @@ export class EdConnectorService {
 
     const apiToken = this.decrypt(existing.apiKeyEncrypted);
     const baseUrl = this.resolveBaseUrl(existing.baseUrl);
-    const courseId = params.courseId ?? this.defaultCourseId;
+    if (!params.courseId) {
+      throw new Error("courseId is required");
+    }
+    const courseId = params.courseId;
     const client = new EdDiscussionClient(baseUrl, apiToken);
 
     const thread = await client.postThread(courseId, {
       title: params.title,
       content: this.buildContentXml(params.body),
+      isAnonymous: params.isAnonymous ?? false,
     });
 
     return {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -45,6 +45,8 @@ import { resolveGetWeeklyOverview } from "./tools/courseTools";
 
 const europeFunctions = functions.region("europe-west6");
 
+// ED Discussion API base URL
+const ED_DEFAULT_BASE_URL = "https://eu.edstem.org/api";
 
 /* ---------- helpers ---------- */
 function withV1(url?: string): string {
@@ -97,7 +99,7 @@ const edConnectorService = new EdConnectorService(
   edConnectorRepository,
   encryptSecret,
   decryptSecret,
-  "https://eu.edstem.org/api"
+  ED_DEFAULT_BASE_URL
 );
 
 /* =========================================================
@@ -1286,7 +1288,7 @@ export const answerWithRagFn = europeFunctions.https.onCall(async (data: AnswerW
           const existing = await edConnectorRepository.getConfig(uid);
           if (existing && existing.apiKeyEncrypted) {
             const apiToken = decryptSecret(existing.apiKeyEncrypted);
-            const baseUrl = existing.baseUrl || "https://eu.edstem.org/api";
+            const baseUrl = existing.baseUrl || ED_DEFAULT_BASE_URL;
             const client = new EdDiscussionClient(baseUrl, apiToken);
             const courses = await client.getCourses();
 
@@ -2044,7 +2046,7 @@ export const edConnectorGetCoursesFn = europeFunctions.https.onCall(
       }
 
       const apiToken = decryptSecret(existing.apiKeyEncrypted);
-      const baseUrl = existing.baseUrl || "https://eu.edstem.org/api";
+      const baseUrl = existing.baseUrl || ED_DEFAULT_BASE_URL;
       const client = new EdDiscussionClient(baseUrl, apiToken);
 
       const courses = await client.getCourses();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -90,18 +90,13 @@ if (!admin.apps.length) {
 }
 const db = admin.firestore();
 
-const ED_DEFAULT_COURSE_ID = Number(
-  process.env.ED_DEFAULT_COURSE_ID || "1153"
-);
-
 // ED Discussion connector (stored in Firestore under connectors_ed/{userId})
 const edConnectorRepository = new EdConnectorRepository(db);
 const edConnectorService = new EdConnectorService(
   edConnectorRepository,
   encryptSecret,
   decryptSecret,
-  "https://eu.edstem.org/api",
-  ED_DEFAULT_COURSE_ID
+  "https://eu.edstem.org/api"
 );
 
 /* =========================================================
@@ -1939,6 +1934,7 @@ type EdConnectorPostCallableInput = {
   title?: string;
   body?: string;
   courseId?: number;
+  isAnonymous?: boolean;
 };
 
 export const edConnectorPostFn = europeFunctions.https.onCall(
@@ -1949,6 +1945,8 @@ export const edConnectorPostFn = europeFunctions.https.onCall(
     const body = String(data?.body || "").trim();
     const courseId =
       typeof data?.courseId === "number" ? data.courseId : undefined;
+    const isAnonymous =
+      typeof data?.isAnonymous === "boolean" ? data.isAnonymous : false;
 
     if (!title && !body) {
       throw new functions.https.HttpsError(
@@ -1957,11 +1955,19 @@ export const edConnectorPostFn = europeFunctions.https.onCall(
       );
     }
 
+    if (!courseId) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "courseId is required"
+      );
+    }
+
     try {
       const result = await edConnectorService.postThread(uid, {
         title,
         body,
         courseId,
+        isAnonymous,
       });
       return result;
     } catch (e: any) {
@@ -1973,6 +1979,46 @@ export const edConnectorPostFn = europeFunctions.https.onCall(
       throw new functions.https.HttpsError(
         "internal",
         "Failed to post ED thread",
+        String(e?.message || e)
+      );
+    }
+  }
+);
+
+export const edConnectorGetCoursesFn = europeFunctions.https.onCall(
+  async (_data, context) => {
+    const uid = requireAuth(context);
+
+    try {
+      const existing = await edConnectorRepository.getConfig(uid);
+      if (!existing || !existing.apiKeyEncrypted) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "ED connector is not connected"
+        );
+      }
+
+      const apiToken = decryptSecret(existing.apiKeyEncrypted);
+      const baseUrl = existing.baseUrl || "https://eu.edstem.org/api";
+      const client = new EdDiscussionClient(baseUrl, apiToken);
+
+      const courses = await client.getCourses();
+      return {
+        courses: courses.map((c) => ({
+          id: c.id,
+          code: c.code,
+          name: c.name,
+        })),
+      };
+    } catch (e: any) {
+      if (e instanceof functions.https.HttpsError) throw e;
+      logger.error("edConnectorGetCoursesFn.failed", {
+        uid,
+        error: String(e),
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        "Failed to get ED courses",
         String(e?.message || e)
       );
     }


### PR DESCRIPTION
## Summary
This PR enhances the ED posting modal by allowing users to better control how their post is published. It adds support for selecting the target course/category via a dropdown and enables optional anonymous posting, while preserving the existing posting flow and default behavior.

## What
- Added a course/category dropdown to the ED posting modal.
- Added an anonymous posting toggle (disabled by default).
- Extended the ED posting payload to include `courseId` and `anonymous`.
- Updated the backend posting logic to forward these parameters to the ED API.
- Handled loading and error states for the new UI elements.
- Ensured backward compatibility when default values are used.
- Automatically detects and preselects the appropriate ED forum based on the selected course/category.

## How
- Fetched available ED courses/categories through the existing backend/MCP connector.
- Introduced new UI state in the posting modal to manage the selected course and anonymous flag.
- Wired the dropdown and toggle to this state with sensible defaults.
- Extended the post confirmation action to include `courseId` and `anonymous` in the request payload.
- Updated the backend `postEd` endpoint to forward these fields unchanged to the ED API.
- Added basic validation and error handling to prevent invalid submissions.
- Implemented automatic forum resolution logic to determine the correct ED forum from the selected course/category before submission.

## Why
The initial ED posting implementation focused on enabling the core posting workflow, but lacked customization options that are essential for real-world usage. Users need to choose the appropriate course/category and sometimes post anonymously. This change completes the posting experience without altering existing behavior for users who don’t need these options.

proof : 
<img width="344" height="525" alt="Capture d&#39;écran 2025-12-13 174139" src="https://github.com/user-attachments/assets/9fa637cc-08ce-4638-9482-5671fe51d89f" />
<img width="1044" height="446" alt="Capture d&#39;écran 2025-12-13 174155" src="https://github.com/user-attachments/assets/637921e3-d781-4c23-a2ca-60afda7a82f4" />

## since this is the last PR about ED posting, Side notes about the final flow of ed posting : 
- Addressed the reviewer feedback from last week (#237) regarding preventing ED posts when the user is not authenticated.
- Instead of silently blocking the action, the posting flow now **fails explicitly at submit time**:
  - The **Post button is disabled / submission fails** if the ED connector is not connected.
  - A clear UI message indicates that **the ED connector is not connected**, guiding the user to authenticate first.
  - However, every other comment have been addressed