### PR TITLE
allow chat input to expand dynamically up to 5 lines

### DIFF
--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.offset
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -74,13 +73,14 @@ import com.android.sample.speech.SpeechToTextHelper
 import com.android.sample.ui.components.EdPostConfirmationModal
 import com.android.sample.ui.components.EdPostedCard
 import com.android.sample.ui.components.GuestProfileWarningModal
+import com.android.sample.ui.theme.Dimensions.InputHeight
+import com.android.sample.ui.theme.Dimensions.InputHorizontal
 import com.android.sample.ui.theme.EdPostDimensions
 import com.android.sample.ui.theme.EulerRed
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.Request
 
 object HomeTags {
   const val Root = "home_root"
@@ -812,9 +812,11 @@ private fun ChatInputBar(
             fontSize = 15.sp,
             fontWeight = FontWeight.Normal)
       },
-      modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp).height(52.dp),
+      modifier =
+          modifier.fillMaxWidth().padding(horizontal = InputHorizontal).heightIn(min = InputHeight),
       enabled = enabled,
-      singleLine = true,
+      singleLine = false,
+      maxLines = 5,
       textStyle =
           MaterialTheme.typography.bodyMedium.copy(
               fontSize = 15.sp, fontWeight = FontWeight.Normal),

--- a/app/src/main/java/com/android/sample/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/android/sample/ui/theme/Dimensions.kt
@@ -10,4 +10,6 @@ object Dimensions {
   val BadgeContentSpacing = 12.dp
   val TextVerticalSpacing = 2.dp
   val BadgeSpacerHeight = 4.dp
+  val InputHorizontal = 16.dp
+  val InputHeight = 52.dp
 }


### PR DESCRIPTION
This PR improves the chat input experience by transforming the text field from a fixed single-line input into a dynamic multi-line input that expands as the user types, up to a maximum height.

---

## What

- Updated the `ChatInputBar` to support multi-line text entry.
- The input field now grows vertically automatically as the user types.
- Implemented a maximum height limit of **4 lines**; beyond this, the text content becomes scrollable inside the field.
- Preserved the original **capsule design** and minimum height when the input is empty.

---

## How

- Modified the `OutlinedTextField` in `ChatInputBar` by changing `singleLine` from `true` to `false`.
- Replaced the fixed `height(52.dp)` modifier with `heightIn(min = 52.dp)`, ensuring the bar starts at the correct design height while allowing vertical expansion.
- Added `maxLines = 4` to constrain vertical growth and trigger internal scrolling for longer messages.

---

## Why

- The previous single-line implementation forced users to scroll horizontally to read long messages, resulting in a poor user experience for a chat/AI interface.
- Users need to be able to easily review and edit longer prompts.
- Allowing the input to grow creates a more natural and standard typing experience, similar to modern messaging apps.
