### PR TITLE
 fix(code): moving all the strings from strings.xml to Localization.kt

### DIFF
--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -577,8 +576,7 @@ fun HomeScreen(
                                       msg.source.compactType != CompactSourceType.NONE) {
                                     Spacer(Modifier.height(8.dp))
                                     val sourceSiteLabel =
-                                        msg.source.siteLabelRes?.let { stringResource(id = it) }
-                                            ?: msg.source.siteLabel.orEmpty()
+                                        msg.source.siteLabel.orEmpty()
                                     SourceCard(
                                         siteLabel = sourceSiteLabel,
                                         title = "",
@@ -748,19 +746,19 @@ internal fun EdPostResultBanner(result: EdPostResult, onDismiss: () -> Unit = {}
     is EdPostResult.Published -> {
       bg = MaterialTheme.colorScheme.surfaceVariant
       icon = Icons.Default.CheckCircle
-      title = stringResource(R.string.ed_post_published_title)
-      subtitle = stringResource(R.string.ed_post_published_subtitle)
+      title = Localization.t("ed_post_published_title")
+      subtitle = Localization.t("ed_post_published_subtitle")
     }
     is EdPostResult.Cancelled -> {
       bg = MaterialTheme.colorScheme.surfaceVariant
       icon = Icons.Default.Close
-      title = stringResource(R.string.ed_post_cancelled_title)
-      subtitle = stringResource(R.string.ed_post_cancelled_subtitle)
+      title = Localization.t("ed_post_cancelled_title")
+      subtitle = Localization.t("ed_post_cancelled_subtitle")
     }
     is EdPostResult.Failed -> {
       bg = MaterialTheme.colorScheme.errorContainer
       icon = Icons.Default.Error
-      title = stringResource(R.string.ed_post_failed_title)
+      title = Localization.t("ed_post_failed_title")
       subtitle = result.message
     }
     else -> {
@@ -788,7 +786,7 @@ internal fun EdPostResultBanner(result: EdPostResult, onDismiss: () -> Unit = {}
                 }
               }
               IconButton(onClick = onDismiss) {
-                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.dismiss))
+                Icon(Icons.Default.Close, contentDescription = Localization.t("dismiss"))
               }
             }
       }

--- a/app/src/main/java/com/android/sample/home/HomeScreen.kt
+++ b/app/src/main/java/com/android/sample/home/HomeScreen.kt
@@ -575,8 +575,7 @@ fun HomeScreen(
                                       !msg.isThinking &&
                                       msg.source.compactType != CompactSourceType.NONE) {
                                     Spacer(Modifier.height(8.dp))
-                                    val sourceSiteLabel =
-                                        msg.source.siteLabel.orEmpty()
+                                    val sourceSiteLabel = msg.source.siteLabel.orEmpty()
                                     SourceCard(
                                         siteLabel = sourceSiteLabel,
                                         title = "",

--- a/app/src/main/java/com/android/sample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/sample/home/HomeViewModel.kt
@@ -2,7 +2,6 @@ package com.android.sample.home
 
 import android.net.Uri
 import android.util.Log
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,7 +9,6 @@ import com.android.sample.BuildConfig
 import com.android.sample.Chat.ChatAttachment
 import com.android.sample.Chat.ChatType
 import com.android.sample.Chat.ChatUIModel
-import com.android.sample.R
 import com.android.sample.conversations.AuthNotReadyException
 import com.android.sample.conversations.CachedResponseRepository
 import com.android.sample.conversations.ConversationRepository
@@ -84,9 +82,7 @@ private fun isRunningOnEmulator(): Boolean {
 
 data class SourceMeta(
     val siteLabel: String? = null, // e.g. "EPFL.ch Website" or "Your Schedule"
-    @StringRes val siteLabelRes: Int? = null,
     val title: String? = null, // e.g. "Projet de Semestre – Bachelor"
-    @StringRes val titleRes: Int? = null,
     val url: String? = null, // null for schedule sources
     val retrievedAt: Long = System.currentTimeMillis(),
     val isScheduleSource: Boolean = false, // DEPRECATED: use compactType instead
@@ -1219,10 +1215,8 @@ class HomeViewModel(
                   SourceType.SCHEDULE -> {
                     // Schedule source - show a small indicator
                     SourceMeta(
-                        siteLabel = FALLBACK_SCHEDULE_LABEL,
-                        siteLabelRes = R.string.source_label_epfl_schedule,
-                        title = FALLBACK_SCHEDULE_TITLE,
-                        titleRes = R.string.source_label_schedule_description,
+                        siteLabel = Localization.t("source_label_epfl_schedule"),
+                        title = Localization.t("source_label_schedule_description"),
                         url = null,
                         isScheduleSource = true,
                         compactType = CompactSourceType.SCHEDULE)
@@ -1230,10 +1224,8 @@ class HomeViewModel(
                   SourceType.FOOD -> {
                     // Food source - show a small indicator
                     SourceMeta(
-                        siteLabel = FALLBACK_FOOD_LABEL,
-                        siteLabelRes = R.string.source_label_epfl_restaurants,
-                        title = FALLBACK_FOOD_TITLE,
-                        titleRes = R.string.source_label_food_description,
+                        siteLabel = Localization.t("source_label_epfl_restaurants"),
+                        title = Localization.t("source_label_food_description"),
                         url = reply.url,
                         isScheduleSource = true,
                         compactType = CompactSourceType.FOOD)

--- a/app/src/main/java/com/android/sample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/sample/home/HomeViewModel.kt
@@ -386,11 +386,7 @@ class HomeViewModel(
     dataStarted = true
     Log.d(TAG, "startData(): attaching listeners (isInLocalNewChat=$isInLocalNewChat)")
 
-    observeConversations()
-    collectMessages()
-  }
-
-  private fun observeConversations() {
+    // 1) Conversation list
     conversationsJob?.cancel()
     conversationsJob =
         viewModelScope.launch {
@@ -399,157 +395,138 @@ class HomeViewModel(
                 TAG,
                 "conversationsFlow -> size=${list.size}, current=${_uiState.value.currentConversationId}, isInLocalNewChat=$isInLocalNewChat")
             _uiState.update { it.copy(conversations = list) }
-            reconcileCurrentSelection(list)
+
+            val currentId = _uiState.value.currentConversationId
+            val hasCurrent = currentId != null && list.any { it.id == currentId }
+
+            when {
+              hasCurrent -> Log.d(TAG, "Keeping current conversation $currentId")
+              currentId == null && list.isNotEmpty() && !isInLocalNewChat -> {
+                val next = list.first().id
+                Log.d(TAG, "Auto-selecting conversation $next (not in local placeholder mode)")
+                isInLocalNewChat = false
+                _uiState.update { it.copy(currentConversationId = next) }
+              }
+              list.isEmpty() -> {
+                Log.d(TAG, "No remote conversations available; staying with null selection")
+                _uiState.update { it.copy(currentConversationId = null) }
+              }
+              else -> Log.d(TAG, "Local new chat active; leaving selection as null")
+            }
           }
         }
-  }
 
-  private fun reconcileCurrentSelection(list: List<com.android.sample.conversations.Conversation>) {
-    val currentId = _uiState.value.currentConversationId
-    val hasCurrent = currentId != null && list.any { it.id == currentId }
-
-    when {
-      hasCurrent -> Log.d(TAG, "Keeping current conversation $currentId")
-      currentId == null && list.isNotEmpty() && !isInLocalNewChat -> {
-        val next = list.first().id
-        Log.d(TAG, "Auto-selecting conversation $next (not in local placeholder mode)")
-        isInLocalNewChat = false
-        _uiState.update { it.copy(currentConversationId = next) }
-      }
-      list.isEmpty() -> {
-        Log.d(TAG, "No remote conversations available; staying with null selection")
-        _uiState.update { it.copy(currentConversationId = null) }
-      }
-      else -> Log.d(TAG, "Local new chat active; leaving selection as null")
-    }
-  }
-
-  @OptIn(ExperimentalCoroutinesApi::class)
-  private fun collectMessages() {
+    // 2) Messages for the selected conversation (flatMapLatest strategy)
     messagesJob?.cancel()
     messagesJob =
         viewModelScope.launch(Dispatchers.IO) {
           uiState
               .map { it.currentConversationId }
               .distinctUntilChanged()
-              .flatMapLatest { cid -> if (cid == null) emptyFlow() else repo.messagesFlow(cid) }
+              .flatMapLatest { cid ->
+                // Use emptyFlow() when no conversation is selected to avoid
+                // race conditions where stale emissions could clear local messages
+                if (cid == null) emptyFlow() else repo.messagesFlow(cid)
+              }
               .flowOn(Dispatchers.IO)
               .collect { msgs ->
-                if (shouldSkipMessageUpdate(msgs)) return@collect
-                updateMessagesWithEdCards(msgs)
+                val streamingId = _uiState.value.streamingMessageId
+                if (streamingId != null) {
+
+                  return@collect
+                }
+
+                val conversationId = _uiState.value.currentConversationId
+
+                // Don't overwrite local messages when no conversation is selected
+                // and incoming messages are empty. This preserves offline messages
+                // that haven't been persisted yet. We always skip in this case
+                // because updating with empty messages is either a no-op (if messages
+                // are already empty) or destructive (if we have local messages).
+                if (conversationId == null && msgs.isEmpty()) {
+                  return@collect
+                }
+                // Load all EdCards (both EdPostCard and EdPostsCard) before updating state
+                val loadedEdCards = mutableListOf<EdPostCard>()
+                val loadedEdPostsCards = mutableListOf<EdPostsCard>()
+
+                if (conversationId != null && !isGuest()) {
+                  val (newEdCards, newEdPostsCards) =
+                      loadEdCardsForMessages(conversationId, msgs, repo = repo)
+                  loadedEdCards.addAll(newEdCards)
+                  loadedEdPostsCards.addAll(newEdPostsCards)
+                }
+
+                withContext(Dispatchers.Main) {
+                  _uiState.update { currentState ->
+                    // Merge loaded EdCards with existing ones (avoid duplicates)
+                    val allEdCards =
+                        (currentState.edPostCards + loadedEdCards)
+                            .distinctBy { it.id }
+                            .sortedBy { it.createdAt }
+
+                    // Merge loaded EdPostsCards with existing ones (avoid duplicates)
+                    val allEdPostsCards =
+                        (currentState.edPostsCards + loadedEdPostsCards)
+                            .distinctBy { it.id }
+                            .sortedBy { it.createdAt }
+
+                    val firestoreMessages = msgs.map { (dto, messageId) -> dto.toUi(messageId) }
+
+                    // Detect if we're switching conversations or syncing the same one
+                    val firestoreTexts =
+                        firestoreMessages
+                            .mapNotNull { it.text.takeIf { t -> t.isNotBlank() } }
+                            .toSet()
+                    val localTexts =
+                        currentState.messages
+                            .mapNotNull { it.text.takeIf { t -> t.isNotBlank() } }
+                            .toSet()
+                    val isSameConversation = firestoreTexts.any { it in localTexts }
+
+                    if (!isSameConversation) {
+                      // Switching conversations - don't preserve local source/attachment
+                      return@update currentState.copy(
+                          messages = firestoreMessages,
+                          edPostCards = allEdCards,
+                          edPostsCards = allEdPostsCards)
+                    }
+
+                    // Same conversation - preserve source/attachment from local state
+                    val localSourceByText =
+                        currentState.messages
+                            .filter { it.type == ChatType.AI && it.source != null }
+                            .associateBy { it.text }
+                    val localAttachmentByText =
+                        currentState.messages
+                            .filter { it.type == ChatType.AI && it.attachment != null }
+                            .associateBy { it.text }
+
+                    val finalMessages =
+                        firestoreMessages.map { msg ->
+                          if (msg.type == ChatType.AI) {
+                            val localSource = localSourceByText[msg.text]?.source
+                            val localAttachment = localAttachmentByText[msg.text]?.attachment
+                            if (localSource != null || localAttachment != null) {
+                              msg.copy(
+                                  source = localSource ?: msg.source,
+                                  attachment = localAttachment ?: msg.attachment)
+                            } else {
+                              msg
+                            }
+                          } else {
+                            msg
+                          }
+                        }
+
+                    currentState.copy(
+                        messages = finalMessages,
+                        edPostCards = allEdCards,
+                        edPostsCards = allEdPostsCards)
+                  }
+                }
               }
         }
-  }
-
-  /**
-   * Guardrail to prevent state corruption during streaming. Skips Firestore message updates when
-   * streaming is active (to avoid overwriting the in-flight placeholder/partial assistant message)
-   * or when there's no current conversation and no incoming messages. These skips are intentional
-   * to preserve local optimistic UI state and maintain consistency while streaming.
-   */
-  private fun shouldSkipMessageUpdate(msgs: List<Pair<MessageDTO, String>>): Boolean {
-    val streamingId = _uiState.value.streamingMessageId
-    if (streamingId != null) return true
-
-    val conversationId = _uiState.value.currentConversationId
-    if (conversationId == null && msgs.isEmpty()) return true
-
-    return false
-  }
-
-  private suspend fun updateMessagesWithEdCards(msgs: List<Pair<MessageDTO, String>>) {
-    val conversationId = _uiState.value.currentConversationId
-    val (loadedEdCards, loadedEdPostsCards) = loadEdCardsIfNeeded(conversationId, msgs)
-
-    withContext(Dispatchers.Main) {
-      _uiState.update { currentState ->
-        val allEdCards = mergeEdCards(currentState.edPostCards, loadedEdCards)
-        val allEdPostsCards = mergeEdPostsCards(currentState.edPostsCards, loadedEdPostsCards)
-        val firestoreMessages = msgs.map { (dto, messageId) -> dto.toUi(messageId) }
-        val finalMessages = mergeMessagesWithLocalState(currentState, firestoreMessages)
-
-        currentState.copy(
-            messages = finalMessages, edPostCards = allEdCards, edPostsCards = allEdPostsCards)
-      }
-    }
-  }
-
-  private suspend fun loadEdCardsIfNeeded(
-      conversationId: String?,
-      msgs: List<Pair<MessageDTO, String>>
-  ): Pair<List<EdPostCard>, List<EdPostsCard>> {
-    if (conversationId == null || isGuest()) {
-      return Pair(emptyList(), emptyList())
-    }
-    return loadEdCardsForMessages(conversationId, msgs, repo = repo)
-  }
-
-  private fun mergeEdCards(existing: List<EdPostCard>, loaded: List<EdPostCard>): List<EdPostCard> {
-    return (existing + loaded).distinctBy { it.id }.sortedBy { it.createdAt }
-  }
-
-  private fun mergeEdPostsCards(
-      existing: List<EdPostsCard>,
-      loaded: List<EdPostsCard>
-  ): List<EdPostsCard> {
-    return (existing + loaded).distinctBy { it.id }.sortedBy { it.createdAt }
-  }
-
-  private fun mergeMessagesWithLocalState(
-      currentState: HomeUiState,
-      firestoreMessages: List<ChatUIModel>
-  ): List<ChatUIModel> {
-    val isSameConversation = detectSameConversation(currentState.messages, firestoreMessages)
-
-    if (!isSameConversation) {
-      return firestoreMessages
-    }
-
-    return preserveLocalSourceAndAttachment(currentState.messages, firestoreMessages)
-  }
-
-  /**
-   * Heuristic to detect if local and Firestore messages belong to the same conversation by checking
-   * for overlapping message text. This is fragile: duplicate/common texts, edits, or formatting
-   * differences may cause false positives/negatives. We use this because stable conversation IDs
-   * are not reliably available in this sync context. If a stable ID or marker becomes available,
-   * prefer that over text-based matching.
-   */
-  private fun detectSameConversation(
-      localMessages: List<ChatUIModel>,
-      firestoreMessages: List<ChatUIModel>
-  ): Boolean {
-    val firestoreTexts =
-        firestoreMessages.mapNotNull { it.text.takeIf { t -> t.isNotBlank() } }.toSet()
-    val localTexts = localMessages.mapNotNull { it.text.takeIf { t -> t.isNotBlank() } }.toSet()
-    return firestoreTexts.any { it in localTexts }
-  }
-
-  private fun preserveLocalSourceAndAttachment(
-      localMessages: List<ChatUIModel>,
-      firestoreMessages: List<ChatUIModel>
-  ): List<ChatUIModel> {
-    val localSourceByText =
-        localMessages.filter { it.type == ChatType.AI && it.source != null }.associateBy { it.text }
-    val localAttachmentByText =
-        localMessages
-            .filter { it.type == ChatType.AI && it.attachment != null }
-            .associateBy { it.text }
-
-    return firestoreMessages.map { msg ->
-      if (msg.type == ChatType.AI) {
-        val localSource = localSourceByText[msg.text]?.source
-        val localAttachment = localAttachmentByText[msg.text]?.attachment
-        if (localSource != null || localAttachment != null) {
-          msg.copy(
-              source = localSource ?: msg.source, attachment = localAttachment ?: msg.attachment)
-        } else {
-          msg
-        }
-      } else {
-        msg
-      }
-    }
   }
 
   /**
@@ -913,55 +890,22 @@ class HomeViewModel(
    */
   fun sendMessage(message: String? = null) {
     val current = _uiState.value
-    if (shouldAbortSend(current)) return
+    if (current.isSending || current.streamingMessageId != null) return
 
-    val msg = normalizeMessageInput(message, current.messageDraft)
+    // Use provided message or fall back to draft
+    val msg = (message?.trim() ?: current.messageDraft.trim())
     if (msg.isEmpty()) return
 
-    updateOfflineStateIfNeeded(current)
-    val (userMsg, aiMessageId) = appendUserMessageToUi(msg)
-
-    viewModelScope.launch(exceptionHandler) {
-      try {
-        Log.d(TAG, "sendMessage: starting, message='${msg.take(50)}...'")
-
-        if (handlePredefinedResponse(msg, aiMessageId)) return@launch
-
-        val isOffline = current.isOffline || networkMonitor?.isCurrentlyOnline() == false
-        if (isOffline && handleOfflineCachedResponse(msg, aiMessageId)) return@launch
-
-        if (isGuest()) {
-          handleGuestModeSend(msg, aiMessageId)
-          return@launch
-        }
-
-        performSignedInSend(msg, userMsg, aiMessageId)
-      } catch (_: AuthNotReadyException) {
-        handleAuthNotReadyError(aiMessageId)
-      } catch (e: Exception) {
-        Log.e(TAG, "Error sending message", e)
-        handleSendMessageError(e, aiMessageId)
-      } catch (t: Throwable) {
-        Log.e(TAG, "Unexpected error sending message", t)
-        handleSendMessageError(t, aiMessageId)
-      } finally {
-        finalizeSend()
+    // Note: We allow sending even when offline to support suggestion chips working offline.
+    // Network errors will be caught and displayed to the user.
+    // Still update offline message state if needed, but don't block sending.
+    if (current.isOffline) {
+      // Update state to show offline message if not already shown
+      if (!current.showOfflineMessage && auth.currentUser != null) {
+        _uiState.update { it.copy(showOfflineMessage = true) }
       }
     }
-  }
-
-  private fun shouldAbortSend(current: HomeUiState): Boolean {
-    return current.isSending || current.streamingMessageId != null
-  }
-
-  private fun normalizeMessageInput(message: String?, draft: String): String {
-    return (message?.trim() ?: draft.trim())
-  }
-
-  private fun updateOfflineStateIfNeeded(current: HomeUiState) {
-    if (current.isOffline && !current.showOfflineMessage && auth.currentUser != null) {
-      _uiState.update { it.copy(showOfflineMessage = true) }
-    }
+    // Double-check actual connectivity and update state, but don't block sending
     if (networkMonitor?.isCurrentlyOnline() == false) {
       _uiState.update {
         it.copy(
@@ -969,9 +913,7 @@ class HomeViewModel(
             showOfflineMessage = if (auth.currentUser != null) true else it.showOfflineMessage)
       }
     }
-  }
 
-  private fun appendUserMessageToUi(msg: String): Pair<ChatUIModel, String> {
     val now = System.currentTimeMillis()
     val userMsg =
         ChatUIModel(
@@ -985,6 +927,7 @@ class HomeViewModel(
             type = ChatType.AI,
             isThinking = true)
 
+    // Optimistic UI: add user + placeholder, clear input, mark streaming state
     _uiState.update { st ->
       st.copy(
           messages = st.messages + userMsg + placeholder,
@@ -994,212 +937,198 @@ class HomeViewModel(
           streamingSequence = st.streamingSequence + 1)
     }
 
-    return userMsg to aiMessageId
-  }
-
-  private suspend fun handlePredefinedResponse(msg: String, aiMessageId: String): Boolean {
-    val canonicalQuestion = getCanonicalQuestion(msg)
-    val predefinedResponse = getPredefinedResponse(canonicalQuestion)
-    if (predefinedResponse != null) {
-      Log.d(TAG, "sendMessage: using predefined response for: $canonicalQuestion")
-      simulateStreamingFromText(aiMessageId, predefinedResponse)
-      clearStreamingState(aiMessageId)
-      return true
-    }
-    return false
-  }
-
-  private suspend fun handleOfflineCachedResponse(msg: String, aiMessageId: String): Boolean {
-    Log.d(TAG, "sendMessage: offline mode, checking Firestore cache")
-
-    if (isGuest()) {
-      handleOfflineError(aiMessageId)
-      return true
-    }
-
-    return try {
-      val canonicalQuestion = getCanonicalQuestion(msg)
-      val cachedResponse = cacheRepo.getCachedResponse(canonicalQuestion, preferCache = true)
-      if (cachedResponse != null && cachedResponse.isNotBlank()) {
-        Log.d(TAG, "sendMessage: found cached response in Firestore local cache")
-        simulateStreamingFromText(aiMessageId, cachedResponse)
-        clearStreamingState(aiMessageId)
-        persistCachedResponseToConversation(cachedResponse)
-        true
-      } else {
-        handleOfflineError(aiMessageId)
-        true
-      }
-    } catch (e: Exception) {
-      Log.w(TAG, "Error checking Firestore local cache", e)
-      handleOfflineError(aiMessageId)
-      true
-    }
-  }
-
-  private suspend fun persistCachedResponseToConversation(cachedResponse: String) {
-    val cid = _uiState.value.currentConversationId
-    if (cid != null) {
+    viewModelScope.launch(exceptionHandler) {
       try {
-        repo.appendMessage(cid, "assistant", cachedResponse)
-      } catch (e: Exception) {
-        Log.w(TAG, "Failed to persist cached response to conversation", e)
-      }
-    }
-  }
+        Log.d(TAG, "sendMessage: starting, message='${msg.take(50)}...'")
 
-  private suspend fun handleOfflineError(aiMessageId: String) {
-    Log.d(TAG, "sendMessage: no offline response available")
-    handleSendMessageError(
-        IOException(
-            "No offline response available for this question. Please connect to the internet."),
-        aiMessageId)
-  }
-
-  private suspend fun handleGuestModeSend(msg: String, aiMessageId: String) {
-    Log.d(TAG, "sendMessage: guest mode, starting streaming")
-    val currentProfile = resolveProfile()
-    val profileContext = buildProfileContext(currentProfile)
-    Log.d(
-        TAG,
-        "sendMessage: Guest mode - profileContext built, hasContext=${profileContext != null}, contextLength=${profileContext?.length ?: 0}")
-    startStreaming(
-        question = msg,
-        messageId = aiMessageId,
-        conversationId = null,
-        summary = null,
-        transcript = null,
-        profileContext = profileContext,
-        userMessageFirestoreId = null)
-  }
-
-  private suspend fun performSignedInSend(msg: String, userMsg: ChatUIModel, aiMessageId: String) {
-    val cid = ensureConversationExists(msg)
-    val userMessageFirestoreId = persistUserMessage(cid, msg, aiMessageId)
-    updateUserMessageId(userMsg.id, userMessageFirestoreId)
-
-    val streamingContext = buildStreamingContextForSend(cid, userMsg.id)
-    startStreaming(
-        question = msg,
-        messageId = aiMessageId,
-        conversationId = cid,
-        summary = streamingContext.summary,
-        transcript = streamingContext.transcript,
-        profileContext = streamingContext.profileContext,
-        userMessageFirestoreId = userMessageFirestoreId)
-  }
-
-  private suspend fun ensureConversationExists(msg: String): String {
-    val existingId = _uiState.value.currentConversationId
-    if (existingId != null) {
-      isInLocalNewChat = false
-      return existingId
-    }
-
-    val quickTitle = ConversationTitleFormatter.localTitleFrom(msg)
-    val newId = repo.startNewConversation(quickTitle)
-    _uiState.update { it.copy(currentConversationId = newId) }
-    isInLocalNewChat = false
-
-    viewModelScope.launch {
-      try {
-        val good = ConversationTitleFormatter.fetchTitle(functions, msg, TAG)
-        if (good.isNotBlank() && good != quickTitle) {
-          repo.updateConversationTitle(newId, good)
+        // Check for predefined responses first (works both online and offline)
+        // This ensures suggestion bubbles always return consistent answers
+        val canonicalQuestion = getCanonicalQuestion(msg)
+        val predefinedResponse = getPredefinedResponse(canonicalQuestion)
+        if (predefinedResponse != null) {
+          Log.d(TAG, "sendMessage: using predefined response for: $canonicalQuestion")
+          simulateStreamingFromText(aiMessageId, predefinedResponse)
+          clearStreamingState(aiMessageId)
+          return@launch
         }
-      } catch (_: Exception) {
-        /* keep provisional */
-      }
-    }
 
-    return newId
-  }
+        // Handle offline mode for non-predefined questions
+        val isOffline = current.isOffline || networkMonitor?.isCurrentlyOnline() == false
+        if (isOffline) {
+          Log.d(TAG, "sendMessage: offline mode, checking Firestore cache")
 
-  private suspend fun persistUserMessage(cid: String, msg: String, aiMessageId: String): String {
-    return try {
-      repo.appendMessage(cid, "user", msg)
-    } catch (e: Exception) {
-      Log.e(TAG, "Failed to persist user message: ${e.message}", e)
-      // handleSendMessageError is the single source of truth for UI error updates.
-      // Rethrow so caller can abort/cleanup; caller must NOT duplicate error UI handling.
-      handleSendMessageError(e, aiMessageId)
-      throw e
-    }
-  }
+          // For signed-in users, try Firestore local cache
+          if (!isGuest()) {
+            try {
+              val cachedResponse =
+                  cacheRepo.getCachedResponse(canonicalQuestion, preferCache = true)
+              if (cachedResponse != null && cachedResponse.isNotBlank()) {
+                Log.d(TAG, "sendMessage: found cached response in Firestore local cache")
+                simulateStreamingFromText(aiMessageId, cachedResponse)
+                clearStreamingState(aiMessageId)
 
-  private fun updateUserMessageId(localId: String, firestoreId: String) {
-    _uiState.update { state ->
-      state.copy(
-          messages =
-              state.messages.map { message ->
-                if (message.id == localId && message.type == ChatType.USER) {
-                  message.copy(id = firestoreId)
-                } else {
-                  message
+                // Persist to conversation if we have one
+                val cid = _uiState.value.currentConversationId
+                if (cid != null) {
+                  try {
+                    repo.appendMessage(cid, "assistant", cachedResponse)
+                  } catch (e: Exception) {
+                    Log.w(TAG, "Failed to persist cached response to conversation", e)
+                  }
                 }
-              })
-    }
-  }
+                return@launch
+              }
+            } catch (e: Exception) {
+              Log.w(TAG, "Error checking Firestore local cache", e)
+            }
+          }
 
-  /**
-   * Context data passed to the LLM for streaming responses.
-   *
-   * @property summary Condensed history of prior messages in the conversation for continuity.
-   * @property transcript Recent voice/text input transcript to provide immediate context.
-   * @property profileContext User profile info (name, role, academic details) for personalization.
-   */
-  private data class SendStreamingContext(
-      val summary: String?,
-      val transcript: String?,
-      val profileContext: String?
-  )
+          // No cached response available - show error
+          Log.d(TAG, "sendMessage: no offline response available")
+          handleSendMessageError(
+              IOException(
+                  "No offline response available for this question. Please connect to the internet."),
+              aiMessageId)
+          return@launch
+        }
 
-  private suspend fun buildStreamingContextForSend(
-      conversationId: String,
-      userMessageId: String
-  ): SendStreamingContext {
-    val uid = auth.currentUser?.uid
-
-    val summary: String? =
-        if (uid != null) {
-          val prior = fetchPriorSummary(uid, conversationId, userMessageId)
-          val source = if (prior != null) "prior" else "none"
+        // GUEST: no Firestore, just streaming UI
+        if (isGuest()) {
+          Log.d(TAG, "sendMessage: guest mode, starting streaming")
+          val currentProfile = resolveProfile()
+          val profileContext = buildProfileContext(currentProfile)
           Log.d(
               TAG,
-              "answerWithRagFn summarySource=$source len=${prior?.length ?: 0} " +
-                  "head='${prior?.take(2000) ?: ""}'")
-          prior
-        } else null
+              "sendMessage: Guest mode - profileContext built, hasContext=${profileContext != null}, contextLength=${profileContext?.length ?: 0}")
+          startStreaming(
+              question = msg,
+              messageId = aiMessageId,
+              conversationId = null,
+              summary = null,
+              transcript = null,
+              profileContext = profileContext,
+              userMessageFirestoreId = null)
+          return@launch
+        }
 
-    val recentTranscript: String? =
-        if (uid != null) {
-          buildRecentTranscript(uid, conversationId, userMessageId)
-        } else null
+        // CONNECTED: ensure we have a conversation and persist the USER message immediately (repo)
+        val cid =
+            _uiState.value.currentConversationId
+                ?: run {
+                  val quickTitle = ConversationTitleFormatter.localTitleFrom(msg)
+                  val newId = repo.startNewConversation(quickTitle)
+                  _uiState.update { it.copy(currentConversationId = newId) }
+                  isInLocalNewChat = false
 
-    val currentProfile = resolveProfile()
-    val profileContext = buildProfileContext(currentProfile)
-    Log.d(
-        TAG,
-        "sendMessage: profileContext built, hasProfile=${currentProfile != null}, hasContext=${profileContext != null}, contextLength=${profileContext?.length ?: 0}")
+                  // Upgrade title in background (ONE time)
+                  launch {
+                    try {
+                      val good = ConversationTitleFormatter.fetchTitle(functions, msg, TAG)
+                      if (good.isNotBlank() && good != quickTitle) {
+                        repo.updateConversationTitle(newId, good)
+                      }
+                    } catch (_: Exception) {
+                      /* keep provisional */
+                    }
+                  }
+                  newId
+                }
 
-    return SendStreamingContext(summary, recentTranscript, profileContext)
-  }
+        isInLocalNewChat = false
+        // Persist USER message to repo immediately
+        // Store the Firestore message ID for potential use in EdCard association
+        val userMessageFirestoreId =
+            try {
+              repo.appendMessage(cid, "user", msg)
+            } catch (e: Exception) {
+              Log.e(TAG, "Failed to persist user message: ${e.message}", e)
+              handleSendMessageError(e, aiMessageId)
+              return@launch
+            }
 
-  private suspend fun handleAuthNotReadyError(aiMessageId: String) {
-    try {
-      setStreamingError(aiMessageId, AuthNotReadyException())
-      clearStreamingState(aiMessageId)
-    } catch (ex: Exception) {
-      Log.e(TAG, "Error setting streaming error state", ex)
-      _uiState.update { it.copy(isSending = false, streamingMessageId = null) }
-    }
-  }
+        // Update the local user message ID with the Firestore ID
+        _uiState.update { state ->
+          state.copy(
+              messages =
+                  state.messages.map { message ->
+                    if (message.id == userMsg.id && message.type == ChatType.USER) {
+                      message.copy(id = userMessageFirestoreId)
+                    } else {
+                      message
+                    }
+                  })
+        }
 
-  private fun finalizeSend() {
-    try {
-      _uiState.update { it.copy(isSending = false) }
-    } catch (ex: Exception) {
-      Log.e(TAG, "Error updating isSending state in finally", ex)
+        // ---------- Firestore + RAG (from second snippet) ----------
+
+        // Note: User message is already persisted via repo.appendMessage() above
+        // The direct Firestore write was removed to avoid duplicate writes and timestamp type
+        // conflicts
+
+        val uid = auth.currentUser?.uid
+        val conversationId = cid // unify naming
+
+        // Retrieve previous rolling summary if available
+        val summary: String? =
+            if (uid != null && conversationId != null) {
+              val prior = fetchPriorSummary(uid, conversationId, userMsg.id)
+              val source = if (prior != null) "prior" else "none"
+              Log.d(
+                  TAG,
+                  "answerWithRagFn summarySource=$source len=${prior?.length ?: 0} " +
+                      "head='${prior?.take(2000) ?: ""}'")
+              prior
+            } else null
+
+        // Build a recent transcript if needed
+        val recentTranscript: String? =
+            if (uid != null && conversationId != null) {
+              buildRecentTranscript(uid, conversationId, userMsg.id)
+            } else null
+
+        // Resolve profile (loads if not already in state)
+        val currentProfile = resolveProfile()
+
+        // Build the user profile context
+        val profileContext = buildProfileContext(currentProfile)
+        Log.d(
+            TAG,
+            "sendMessage: profileContext built, hasProfile=${currentProfile != null}, hasContext=${profileContext != null}, contextLength=${profileContext?.length ?: 0}")
+
+        // Appel RAG
+        startStreaming(
+            question = msg,
+            messageId = aiMessageId,
+            conversationId = conversationId,
+            summary = summary,
+            transcript = recentTranscript,
+            profileContext = profileContext,
+            userMessageFirestoreId = userMessageFirestoreId)
+      } catch (_: AuthNotReadyException) {
+        // Auth not ready: signal streaming/send error in UI
+        try {
+          setStreamingError(aiMessageId, AuthNotReadyException())
+          clearStreamingState(aiMessageId)
+        } catch (ex: Exception) {
+          Log.e(TAG, "Error setting streaming error state", ex)
+          _uiState.update { it.copy(isSending = false, streamingMessageId = null) }
+        }
+      } catch (e: Exception) {
+        // Erreurs back-end / Functions
+        Log.e(TAG, "Error sending message", e)
+        handleSendMessageError(e, aiMessageId)
+      } catch (t: Throwable) {
+        // Catch any other Throwable (Error, etc.) to prevent crashes
+        Log.e(TAG, "Unexpected error sending message", t)
+        handleSendMessageError(t, aiMessageId)
+      } finally {
+        // Always stop the global sending indicator
+        try {
+          _uiState.update { it.copy(isSending = false) }
+        } catch (ex: Exception) {
+          Log.e(TAG, "Error updating isSending state in finally", ex)
+        }
+      }
     }
   }
   /** Streaming helper using [LlmClient] and optional summary/transcript/profile context. */
@@ -1216,238 +1145,189 @@ class HomeViewModel(
     userCancelledStream = false
 
     activeStreamJob =
-        startStreamingJob(
-            question,
-            messageId,
-            conversationId,
-            summary,
-            transcript,
-            profileContext,
-            userMessageFirestoreId)
-  }
+        viewModelScope.launch(exceptionHandler) {
+          try {
+            Log.d(
+                TAG,
+                "startStreaming: calling llmClient.generateReply for messageId=$messageId, question='${question.take(50)}...'")
+            val reply =
+                try {
+                  withContext(Dispatchers.IO) {
+                    llmClient.generateReply(
+                        prompt = question,
+                        summary = summary,
+                        transcript = transcript,
+                        profileContext = profileContext)
+                  }
+                } catch (e: FirebaseFunctionsException) {
+                  Log.e(
+                      TAG,
+                      "Firebase Functions exception in startStreaming: code=${e.code}, message=${e.message}",
+                      e)
+                  throw e
+                } catch (e: Exception) {
+                  Log.e(TAG, "Exception in llmClient.generateReply: ${e.javaClass.simpleName}", e)
+                  throw e
+                } catch (t: Throwable) {
+                  Log.e(
+                      TAG,
+                      "Unexpected throwable in llmClient.generateReply: ${t.javaClass.simpleName}",
+                      t)
+                  throw t
+                }
+            Log.d(
+                TAG,
+                "startStreaming: received reply, length=${reply.reply.length}, edIntentDetected=${reply.edIntent.detected}, edIntent=${reply.edIntent.intent}, edFetchIntentDetected=${reply.edFetchIntent.detected}, edFetchQuery=${reply.edFetchIntent.query}")
 
-  private fun startStreamingJob(
-      question: String,
-      messageId: String,
-      conversationId: String?,
-      summary: String?,
-      transcript: String?,
-      profileContext: String?,
-      userMessageFirestoreId: String?
-  ): Job {
-    return viewModelScope.launch(exceptionHandler) {
-      try {
-        val reply = generateLlmReply(question, summary, transcript, profileContext)
-        processStreamingReply(reply, question, messageId, conversationId, userMessageFirestoreId)
-      } catch (ce: CancellationException) {
-        handleStreamingCancellation(messageId, ce)
-      } catch (t: Throwable) {
-        handleStreamingError(messageId, t)
-      } finally {
-        finalizeStreaming(messageId)
-      }
-    }
-  }
-
-  private suspend fun generateLlmReply(
-      question: String,
-      summary: String?,
-      transcript: String?,
-      profileContext: String?
-  ): BotReply {
-    Log.d(
-        TAG,
-        "startStreaming: calling llmClient.generateReply for question='${question.take(50)}...'")
-    return try {
-      withContext(Dispatchers.IO) {
-        llmClient.generateReply(
-            prompt = question,
-            summary = summary,
-            transcript = transcript,
-            profileContext = profileContext)
-      }
-    } catch (e: FirebaseFunctionsException) {
-      Log.e(
-          TAG,
-          "Firebase Functions exception in startStreaming: code=${e.code}, message=${e.message}",
-          e)
-      throw e
-    } catch (e: Exception) {
-      Log.e(TAG, "Exception in llmClient.generateReply: ${e.javaClass.simpleName}", e)
-      throw e
-    } catch (t: Throwable) {
-      Log.e(TAG, "Unexpected throwable in llmClient.generateReply: ${t.javaClass.simpleName}", t)
-      throw t
-    }
-  }
-
-  private suspend fun processStreamingReply(
-      reply: BotReply,
-      question: String,
-      messageId: String,
-      conversationId: String?,
-      userMessageFirestoreId: String?
-  ) {
-    Log.d(
-        TAG,
-        "startStreaming: received reply, length=${reply.reply.length}, edIntentDetected=${reply.edIntent.detected}, edIntent=${reply.edIntent.intent}, edFetchIntentDetected=${reply.edFetchIntent.detected}, edFetchQuery=${reply.edFetchIntent.query}")
-
-    val userMessageId =
-        userMessageFirestoreId
-            ?: _uiState.value.messages.lastOrNull { it.type == ChatType.USER }?.id
-
-    if (handleEdFetchIntent(reply, question, messageId, userMessageId)) {
-      Log.d(TAG, "startStreaming: ED fetch intent handled, skipping normal streaming")
-      return
-    }
-
-    if (handleEdIntent(reply, question, messageId)) {
-      Log.d(TAG, "startStreaming: ED post intent handled, skipping normal streaming")
-      return
-    }
-
-    simulateStreamingFromText(messageId, reply.reply)
-
-    val attachment = buildAttachment(reply.url)
-    val sourceMeta = buildSourceMetadata(reply)
-
-    if (attachment != null || sourceMeta != null) {
-      updateMessageWithAttachmentAndSource(messageId, attachment, sourceMeta)
-    }
-
-    if (conversationId != null) {
-      persistAssistantMessage(conversationId, reply.reply, sourceMeta, messageId)
-    }
-  }
-
-  private fun buildAttachment(url: String?): ChatAttachment? {
-    return url?.takeIf { isPdfUrl(it) }?.let { pdfUrl -> ChatAttachment(url = pdfUrl) }
-  }
-
-  private fun buildSourceMetadata(reply: BotReply): SourceMeta? {
-    return when (reply.sourceType) {
-      SourceType.SCHEDULE -> {
-        SourceMeta(
-            siteLabel = FALLBACK_SCHEDULE_LABEL,
-            siteLabelRes = R.string.source_label_epfl_schedule,
-            title = FALLBACK_SCHEDULE_TITLE,
-            titleRes = R.string.source_label_schedule_description,
-            url = null,
-            isScheduleSource = true,
-            compactType = CompactSourceType.SCHEDULE)
-      }
-      SourceType.FOOD -> {
-        SourceMeta(
-            siteLabel = FALLBACK_FOOD_LABEL,
-            siteLabelRes = R.string.source_label_epfl_restaurants,
-            title = FALLBACK_FOOD_TITLE,
-            titleRes = R.string.source_label_food_description,
-            url = reply.url,
-            isScheduleSource = true,
-            compactType = CompactSourceType.FOOD)
-      }
-      SourceType.RAG -> {
-        reply.url?.let { url ->
-          SourceMeta(
-              siteLabel = buildSiteLabel(url),
-              title = buildFallbackTitle(url),
-              url = url,
-              isScheduleSource = false,
-              compactType = CompactSourceType.NONE)
-        }
-      }
-      SourceType.NONE -> null
-    }
-  }
-
-  private fun updateMessageWithAttachmentAndSource(
-      messageId: String,
-      attachment: ChatAttachment?,
-      sourceMeta: SourceMeta?
-  ) {
-    _uiState.update { state ->
-      val updated =
-          state.messages.map { msg ->
-            if (msg.id == messageId) {
-              msg.copy(attachment = attachment ?: msg.attachment, source = sourceMeta ?: msg.source)
+            // Handle ED fetch intent detection first (takes precedence)
+            // Use the Firestore ID if provided, otherwise find the last USER message in the current
+            // state
+            val userMessageId =
+                userMessageFirestoreId
+                    ?: _uiState.value.messages.lastOrNull { it.type == ChatType.USER }?.id
+            if (handleEdFetchIntent(reply, question, messageId, userMessageId)) {
+              Log.d(TAG, "startStreaming: ED fetch intent handled, skipping normal streaming")
+              // Skip normal streaming; ED fetch flow takes over
+              return@launch
             } else {
-              msg
+              Log.d(
+                  TAG,
+                  "startStreaming: No ED fetch intent detected, continuing with normal streaming")
             }
-          }
-      state.copy(messages = updated, streamingSequence = state.streamingSequence + 1)
-    }
-  }
 
-  private suspend fun persistAssistantMessage(
-      conversationId: String,
-      replyText: String,
-      sourceMeta: SourceMeta?,
-      messageId: String
-  ) {
-    try {
-      val sourceMetadata =
-          sourceMeta?.url?.let { url ->
-            com.android.sample.conversations.MessageSourceMetadata(
-                url = url, compactType = sourceMeta.compactType.name)
-          }
-      repo.appendMessage(
-          conversationId = conversationId,
-          role = "assistant",
-          text = replyText,
-          edCardId = null,
-          sourceMetadata = sourceMetadata)
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to persist assistant message: ${e.message}")
-      // handleSendMessageError is the single source of truth for UI error updates.
-      // Rethrow so caller can abort/cleanup; caller must NOT duplicate error UI handling.
-      handleSendMessageError(e, messageId)
-      throw e
-    }
-  }
+            // Handle ED intent detection - create PostOnEd pending action
+            val postHandled = handleEdIntent(reply, question, messageId)
+            if (postHandled) {
+              // Skip normal streaming; ED flow takes over
+              return@launch
+            }
 
-  private suspend fun handleStreamingCancellation(messageId: String, ce: CancellationException) {
-    if (!userCancelledStream) {
-      try {
-        setStreamingError(messageId, ce)
-      } catch (ex: Exception) {
-        Log.e(TAG, "Error setting streaming error for cancellation", ex)
-      }
-    }
-  }
+            // simulate stream into the placeholder AI message
+            simulateStreamingFromText(messageId, reply.reply)
 
-  private suspend fun handleStreamingError(messageId: String, t: Throwable) {
-    Log.e(TAG, "Unexpected error during streaming", t)
-    if (!userCancelledStream) {
-      try {
-        setStreamingError(messageId, t)
-      } catch (ex: Exception) {
-        Log.e(TAG, "Error setting streaming error", ex)
-        _uiState.update { state ->
-          state.copy(
-              messages =
-                  state.messages.map { msg ->
-                    if (msg.id == messageId) {
-                      msg.copy(text = "Error: ${t.message ?: "Unknown error"}", isThinking = false)
-                    } else {
-                      msg
+            // Build attachment if backend returned a PDF URL
+            val attachment: ChatAttachment? =
+                reply.url?.takeIf { isPdfUrl(it) }?.let { pdfUrl -> ChatAttachment(url = pdfUrl) }
+
+            // Build optional source card based on source type
+            val sourceMeta: SourceMeta? =
+                when (reply.sourceType) {
+                  SourceType.SCHEDULE -> {
+                    // Schedule source - show a small indicator
+                    SourceMeta(
+                        siteLabel = Localization.t("source_label_epfl_schedule"),
+                        title = Localization.t("source_label_schedule_description"),
+                        url = null,
+                        isScheduleSource = true,
+                        compactType = CompactSourceType.SCHEDULE)
+                  }
+                  SourceType.FOOD -> {
+                    // Food source - show a small indicator
+                    SourceMeta(
+                        siteLabel = Localization.t("source_label_epfl_restaurants"),
+                        title = Localization.t("source_label_food_description"),
+                        url = reply.url,
+                        isScheduleSource = true,
+                        compactType = CompactSourceType.FOOD)
+                  }
+                  SourceType.RAG -> {
+                    // RAG source - show the web source card if URL exists
+                    reply.url?.let { url ->
+                      SourceMeta(
+                          siteLabel = buildSiteLabel(url),
+                          title = buildFallbackTitle(url),
+                          url = url,
+                          isScheduleSource = false,
+                          compactType = CompactSourceType.NONE)
                     }
-                  },
-              streamingMessageId = null,
-              isSending = false)
-        }
-      }
-    }
-  }
+                  }
+                  SourceType.NONE -> null
+                }
 
-  private suspend fun finalizeStreaming(messageId: String) {
-    try {
-      clearStreamingState(messageId)
-    } catch (ex: Exception) {
-      Log.e(TAG, "Error clearing streaming state", ex)
-      _uiState.update { it.copy(streamingMessageId = null, isSending = false) }
-    }
-    activeStreamJob = null
-    userCancelledStream = false
+            // Update the existing AI message with attachment and/or source (instead of creating new
+            // messages)
+            if (attachment != null || sourceMeta != null) {
+              _uiState.update { state ->
+                val updated =
+                    state.messages.map { msg ->
+                      if (msg.id == messageId) {
+                        msg.copy(
+                            attachment = attachment ?: msg.attachment,
+                            source = sourceMeta ?: msg.source)
+                      } else {
+                        msg
+                      }
+                    }
+                state.copy(messages = updated, streamingSequence = state.streamingSequence + 1)
+              }
+            }
+
+            // Persist assistant message if we are signed in
+            if (conversationId != null) {
+              try {
+                // Use repository method which handles timestamps correctly
+                // Include source metadata for persistence across conversation switches
+                val sourceMetadata =
+                    sourceMeta?.url?.let { url ->
+                      com.android.sample.conversations.MessageSourceMetadata(
+                          url = url, compactType = sourceMeta.compactType.name)
+                    }
+                repo.appendMessage(
+                    conversationId = conversationId,
+                    role = "assistant",
+                    text = reply.reply,
+                    edCardId = null,
+                    sourceMetadata = sourceMetadata)
+              } catch (e: Exception) {
+                Log.w(TAG, "Failed to persist assistant message: ${e.message}")
+                handleSendMessageError(e, messageId)
+                return@launch
+              }
+            }
+          } catch (ce: CancellationException) {
+            if (!userCancelledStream) {
+              try {
+                setStreamingError(messageId, ce)
+              } catch (ex: Exception) {
+                Log.e(TAG, "Error setting streaming error for cancellation", ex)
+              }
+            }
+          } catch (t: Throwable) {
+            Log.e(TAG, "Unexpected error during streaming", t)
+            if (!userCancelledStream) {
+              try {
+                setStreamingError(messageId, t)
+              } catch (ex: Exception) {
+                Log.e(TAG, "Error setting streaming error", ex)
+                // Fallback: directly update UI state
+                _uiState.update { state ->
+                  state.copy(
+                      messages =
+                          state.messages.map { msg ->
+                            if (msg.id == messageId) {
+                              msg.copy(
+                                  text = "Error: ${t.message ?: "Unknown error"}",
+                                  isThinking = false)
+                            } else {
+                              msg
+                            }
+                          },
+                      streamingMessageId = null,
+                      isSending = false)
+                }
+              }
+            }
+          } finally {
+            try {
+              clearStreamingState(messageId)
+            } catch (ex: Exception) {
+              Log.e(TAG, "Error clearing streaming state", ex)
+              _uiState.update { it.copy(streamingMessageId = null, isSending = false) }
+            }
+            activeStreamJob = null
+            userCancelledStream = false
+          }
+        }
   }
 
   private fun buildSiteLabel(url: String): String {

--- a/app/src/main/java/com/android/sample/settings/Localization.kt
+++ b/app/src/main/java/com/android/sample/settings/Localization.kt
@@ -318,7 +318,33 @@ object Localization {
           "epfl_connected_info" to "Your schedule is now connected to the AI assistant.",
           "epfl_clipboard_detected" to "ICS URL detected!",
           "not_now" to "Not now",
-          "use_this_url" to "Use this URL") +
+          "use_this_url" to "Use this URL",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "Invalid URL",
+          "error_failed_to_disconnect" to "Failed to disconnect",
+          "error_could_not_open_epfl_campus" to "Could not open EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Your EPFL Schedule",
+          "source_label_schedule_description" to "Retrieved from your connected calendar",
+          "source_label_epfl_restaurants" to "EPFL Restaurants",
+          "source_label_food_description" to "Retrieved from Pocket Campus",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Title",
+          "ed_post_body_placeholder" to "Your question for ED…",
+          "ed_post_cancel_button" to "Cancel",
+          "ed_post_post_button" to "Post",
+          "select_course" to "Select a course",
+          "post_anonymously" to "Post anonymously",
+          "ed_post_published_title" to "Posted to Ed",
+          "ed_post_published_subtitle" to "Your question was published.",
+          "ed_post_cancelled_title" to "Post cancelled",
+          "ed_post_cancelled_subtitle" to "Draft was discarded.",
+          "ed_post_failed_title" to "Failed to post on Ed",
+          "ed_post_failed_default" to "Failed to post to Ed",
+          "dismiss" to "Dismiss") +
           edTranslationsEn() +
           mapOf(
               "moodle_connect_generic_error" to "Failed to connect to Moodle. Please try again.",
@@ -437,7 +463,33 @@ object Localization {
               "Votre emploi du temps est maintenant connecté à l'assistant IA.",
           "epfl_clipboard_detected" to "URL ICS détectée !",
           "not_now" to "Plus tard",
-          "use_this_url" to "Utiliser cette URL") +
+          "use_this_url" to "Utiliser cette URL",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "URL invalide",
+          "error_failed_to_disconnect" to "Échec de la déconnexion",
+          "error_could_not_open_epfl_campus" to "Impossible d'ouvrir EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Votre emploi du temps EPFL",
+          "source_label_schedule_description" to "Récupéré depuis votre calendrier connecté",
+          "source_label_epfl_restaurants" to "Restaurants EPFL",
+          "source_label_food_description" to "Récupéré depuis Pocket Campus",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Titre",
+          "ed_post_body_placeholder" to "Votre question pour ED…",
+          "ed_post_cancel_button" to "Annuler",
+          "ed_post_post_button" to "Publier",
+          "select_course" to "Sélectionner un cours",
+          "post_anonymously" to "Publier anonymement",
+          "ed_post_published_title" to "Publié sur Ed",
+          "ed_post_published_subtitle" to "Votre question a été publiée.",
+          "ed_post_cancelled_title" to "Publication annulée",
+          "ed_post_cancelled_subtitle" to "Le brouillon a été supprimé.",
+          "ed_post_failed_title" to "Échec de la publication sur Ed",
+          "ed_post_failed_default" to "Échec de la publication sur Ed",
+          "dismiss" to "Fermer") +
           edTranslationsFr() +
           mapOf(
               "moodle_connect_generic_error" to
@@ -548,7 +600,33 @@ object Localization {
           "recent_cs220_exam" to "CS220 Abschlussprüfung Abruf",
           "recent_linear_algebra" to "Lineare Algebra Hilfe",
           "recent_deadline" to "Projekt-Frist Anfrage",
-          "recent_registration" to "Kursanmeldung Info") +
+          "recent_registration" to "Kursanmeldung Info",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "Ungültige URL",
+          "error_failed_to_disconnect" to "Trennung fehlgeschlagen",
+          "error_could_not_open_epfl_campus" to "EPFL Campus konnte nicht geöffnet werden",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Ihr EPFL-Stundenplan",
+          "source_label_schedule_description" to "Aus Ihrem verbundenen Kalender abgerufen",
+          "source_label_epfl_restaurants" to "EPFL Restaurants",
+          "source_label_food_description" to "Von Pocket Campus abgerufen",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Titel",
+          "ed_post_body_placeholder" to "Ihre Frage für ED…",
+          "ed_post_cancel_button" to "Abbrechen",
+          "ed_post_post_button" to "Veröffentlichen",
+          "select_course" to "Kurs auswählen",
+          "post_anonymously" to "Anonym veröffentlichen",
+          "ed_post_published_title" to "Auf Ed veröffentlicht",
+          "ed_post_published_subtitle" to "Ihre Frage wurde veröffentlicht.",
+          "ed_post_cancelled_title" to "Veröffentlichung abgebrochen",
+          "ed_post_cancelled_subtitle" to "Der Entwurf wurde verworfen.",
+          "ed_post_failed_title" to "Veröffentlichung auf Ed fehlgeschlagen",
+          "ed_post_failed_default" to "Veröffentlichung auf Ed fehlgeschlagen",
+          "dismiss" to "Schließen") +
           edTranslationsDe() +
           mapOf(
               "moodle_connect_generic_error" to
@@ -647,7 +725,33 @@ object Localization {
           "recent_cs220_exam" to "Recuperación examen final CS220",
           "recent_linear_algebra" to "Ayuda con álgebra lineal",
           "recent_deadline" to "Consulta fecha límite proyecto",
-          "recent_registration" to "Info inscripción cursos") +
+          "recent_registration" to "Info inscripción cursos",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "URL inválida",
+          "error_failed_to_disconnect" to "Error al desconectar",
+          "error_could_not_open_epfl_campus" to "No se pudo abrir EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Tu horario EPFL",
+          "source_label_schedule_description" to "Obtenido de tu calendario conectado",
+          "source_label_epfl_restaurants" to "Restaurantes EPFL",
+          "source_label_food_description" to "Obtenido de Pocket Campus",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Título",
+          "ed_post_body_placeholder" to "Tu pregunta para ED…",
+          "ed_post_cancel_button" to "Cancelar",
+          "ed_post_post_button" to "Publicar",
+          "select_course" to "Seleccionar un curso",
+          "post_anonymously" to "Publicar anónimamente",
+          "ed_post_published_title" to "Publicado en Ed",
+          "ed_post_published_subtitle" to "Tu pregunta fue publicada.",
+          "ed_post_cancelled_title" to "Publicación cancelada",
+          "ed_post_cancelled_subtitle" to "El borrador fue descartado.",
+          "ed_post_failed_title" to "Error al publicar en Ed",
+          "ed_post_failed_default" to "Error al publicar en Ed",
+          "dismiss" to "Cerrar") +
           edTranslationsEs() +
           mapOf(
               "moodle_connect_generic_error" to
@@ -746,7 +850,33 @@ object Localization {
           "recent_cs220_exam" to "Recupero esame finale CS220",
           "recent_linear_algebra" to "Aiuto con algebra lineare",
           "recent_deadline" to "Richiesta scadenza progetto",
-          "recent_registration" to "Info iscrizione corsi") +
+          "recent_registration" to "Info iscrizione corsi",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "URL non valido",
+          "error_failed_to_disconnect" to "Disconnessione fallita",
+          "error_could_not_open_epfl_campus" to "Impossibile aprire EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Il tuo orario EPFL",
+          "source_label_schedule_description" to "Recuperato dal tuo calendario connesso",
+          "source_label_epfl_restaurants" to "Ristoranti EPFL",
+          "source_label_food_description" to "Recuperato da Pocket Campus",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Titolo",
+          "ed_post_body_placeholder" to "La tua domanda per ED…",
+          "ed_post_cancel_button" to "Annulla",
+          "ed_post_post_button" to "Pubblica",
+          "select_course" to "Seleziona un corso",
+          "post_anonymously" to "Pubblica in modo anonimo",
+          "ed_post_published_title" to "Pubblicato su Ed",
+          "ed_post_published_subtitle" to "La tua domanda è stata pubblicata.",
+          "ed_post_cancelled_title" to "Pubblicazione annullata",
+          "ed_post_cancelled_subtitle" to "La bozza è stata eliminata.",
+          "ed_post_failed_title" to "Pubblicazione su Ed fallita",
+          "ed_post_failed_default" to "Pubblicazione su Ed fallita",
+          "dismiss" to "Chiudi") +
           edTranslationsIt() +
           mapOf(
               "moodle_connect_generic_error" to "Connessione a Moodle fallita. Riprova.",
@@ -844,7 +974,33 @@ object Localization {
           "recent_cs220_exam" to "Recuperação exame final CS220",
           "recent_linear_algebra" to "Ajuda com álgebra linear",
           "recent_deadline" to "Consulta prazo projeto",
-          "recent_registration" to "Info inscrição cursos") +
+          "recent_registration" to "Info inscrição cursos",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "URL inválida",
+          "error_failed_to_disconnect" to "Falha ao desconectar",
+          "error_could_not_open_epfl_campus" to "Não foi possível abrir EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "Seu horário EPFL",
+          "source_label_schedule_description" to "Recuperado do seu calendário conectado",
+          "source_label_epfl_restaurants" to "Restaurantes EPFL",
+          "source_label_food_description" to "Recuperado do Pocket Campus",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "Título",
+          "ed_post_body_placeholder" to "Sua pergunta para ED…",
+          "ed_post_cancel_button" to "Cancelar",
+          "ed_post_post_button" to "Publicar",
+          "select_course" to "Selecionar um curso",
+          "post_anonymously" to "Publicar anonimamente",
+          "ed_post_published_title" to "Publicado no Ed",
+          "ed_post_published_subtitle" to "Sua pergunta foi publicada.",
+          "ed_post_cancelled_title" to "Publicação cancelada",
+          "ed_post_cancelled_subtitle" to "O rascunho foi descartado.",
+          "ed_post_failed_title" to "Falha ao publicar no Ed",
+          "ed_post_failed_default" to "Falha ao publicar no Ed",
+          "dismiss" to "Fechar") +
           edTranslationsPt() +
           mapOf(
               "moodle_connect_generic_error" to "Falha ao conectar ao Moodle. Tente novamente.",
@@ -941,7 +1097,33 @@ object Localization {
           "recent_cs220_exam" to "CS220 期末考试检索",
           "recent_linear_algebra" to "线性代数帮助",
           "recent_deadline" to "项目截止日期查询",
-          "recent_registration" to "课程注册信息") +
+          "recent_registration" to "课程注册信息",
+
+          // EPFL Campus Connector - Errors
+          "error_invalid_url" to "无效的URL",
+          "error_failed_to_disconnect" to "断开连接失败",
+          "error_could_not_open_epfl_campus" to "无法打开EPFL Campus",
+
+          // Source Labels
+          "source_label_epfl_schedule" to "您的EPFL课程表",
+          "source_label_schedule_description" to "从您连接的日历中获取",
+          "source_label_epfl_restaurants" to "EPFL餐厅",
+          "source_label_food_description" to "从Pocket Campus获取",
+
+          // ED Post Confirmation Modal
+          "ed_post_title_placeholder" to "标题",
+          "ed_post_body_placeholder" to "您在ED上的问题…",
+          "ed_post_cancel_button" to "取消",
+          "ed_post_post_button" to "发布",
+          "select_course" to "选择课程",
+          "post_anonymously" to "匿名发布",
+          "ed_post_published_title" to "已发布到Ed",
+          "ed_post_published_subtitle" to "您的问题已发布。",
+          "ed_post_cancelled_title" to "发布已取消",
+          "ed_post_cancelled_subtitle" to "草稿已删除。",
+          "ed_post_failed_title" to "发布到Ed失败",
+          "ed_post_failed_default" to "发布到Ed失败",
+          "dismiss" to "关闭") +
           edTranslationsZh() +
           mapOf(
               "moodle_connect_generic_error" to "连接到 Moodle 失败。请重试。",

--- a/app/src/main/java/com/android/sample/settings/Localization.kt
+++ b/app/src/main/java/com/android/sample/settings/Localization.kt
@@ -7,7 +7,6 @@ package com.android.sample.settings
 object Localization {
   private const val BASE_URL_OPTIONAL_DE = "Basis-URL (optional)"
   private const val BASE_URL_OPTIONAL_ES = "URL base (opcional)"
-  private const val LOGO_EULER = "Logo Euler"
 
   /**
    * Translate a key to the current language string. Falls back to English if the key is not found
@@ -427,7 +426,7 @@ object Localization {
           "cancel" to "Annuler",
 
           // Drawer
-          "euler_logo" to LOGO_EULER,
+          "euler_logo" to "Logo Euler",
           "new_chat" to "Nouveau chat",
           "recents" to "RÉCENTS",
           "view_all_chats" to "Voir tous les chats",
@@ -836,7 +835,7 @@ object Localization {
           "cancel" to "Annulla",
 
           // Drawer
-          "euler_logo" to LOGO_EULER,
+          "euler_logo" to "Logo Euler",
           "new_chat" to "Nuova chat",
           "recents" to "RECENTI",
           "view_all_chats" to "Visualizza tutte le chat",
@@ -960,7 +959,7 @@ object Localization {
           "cancel" to "Cancelar",
 
           // Drawer
-          "euler_logo" to LOGO_EULER,
+          "euler_logo" to "Logo Euler",
           "new_chat" to "Novo chat",
           "recents" to "RECENTES",
           "view_all_chats" to "Ver todos os chats",

--- a/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
+++ b/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
@@ -14,10 +14,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import com.android.sample.R
+import com.android.sample.settings.Localization
 import com.android.sample.home.EdCourse
 import com.android.sample.ui.theme.DarkBackground
 import com.android.sample.ui.theme.EdPostBorderSecondary
@@ -144,7 +143,7 @@ private fun CourseDropdown(
           val selectedCourse = courses.find { it.id == selectedCourseId }
           val displayText =
               selectedCourse?.let { "${it.code ?: ""} ${it.name}".trim() }
-                  ?: stringResource(R.string.select_course)
+                  ?: Localization.t("select_course")
 
           OutlinedTextField(
               value = displayText,
@@ -154,7 +153,7 @@ private fun CourseDropdown(
               modifier = Modifier.fillMaxWidth().menuAnchor(),
               placeholder = {
                 Text(
-                    text = stringResource(R.string.select_course),
+                    text = Localization.t("select_course"),
                     color = textSecondary,
                     fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
               },
@@ -216,7 +215,7 @@ private fun EdPostTitleField(
       modifier = Modifier.fillMaxWidth(),
       placeholder = {
         Text(
-            text = stringResource(R.string.ed_post_title_placeholder),
+            text = Localization.t("ed_post_title_placeholder"),
             color = textSecondary,
             fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
       },
@@ -263,7 +262,7 @@ private fun EdPostBodyField(
                   max = EdPostDimensions.TextFieldBodyMaxHeight),
       placeholder = {
         Text(
-            text = stringResource(R.string.ed_post_body_placeholder),
+            text = Localization.t("ed_post_body_placeholder"),
             color = textSecondary,
             fontSize = EdPostDimensions.TextFieldPlaceholderFontSize)
       },
@@ -299,7 +298,7 @@ private fun AnonymousToggle(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.SpaceBetween) {
         Text(
-            text = stringResource(R.string.post_anonymously),
+            text = Localization.t("post_anonymously"),
             style =
                 MaterialTheme.typography.bodyMedium.copy(
                     fontSize = EdPostDimensions.TextFieldBodyFontSize, color = EdPostTextPrimary))
@@ -338,7 +337,7 @@ private fun EdPostActionButtons(
             shape = RoundedCornerShape(EdPostDimensions.ButtonCancelCornerRadius),
             border = BorderStroke(EdPostDimensions.ButtonBorderWidth, EdPostBorderSecondary)) {
               Text(
-                  text = stringResource(R.string.ed_post_cancel_button),
+                  text = Localization.t("ed_post_cancel_button"),
                   fontSize = EdPostDimensions.ButtonTextFontSize,
                   fontWeight = FontWeight.Medium)
             }
@@ -363,7 +362,7 @@ private fun EdPostActionButtons(
                         horizontalArrangement = Arrangement.Center,
                         verticalAlignment = Alignment.CenterVertically) {
                           Text(
-                              text = stringResource(R.string.ed_post_post_button),
+                              text = Localization.t("ed_post_post_button"),
                               fontSize = EdPostDimensions.ButtonTextFontSize,
                               fontWeight = FontWeight.Bold,
                               color = EdPostTextPrimary)

--- a/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
+++ b/app/src/main/java/com/android/sample/ui/components/EdPostConfirmationModal.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import com.android.sample.settings.Localization
 import com.android.sample.home.EdCourse
+import com.android.sample.settings.Localization
 import com.android.sample.ui.theme.DarkBackground
 import com.android.sample.ui.theme.EdPostBorderSecondary
 import com.android.sample.ui.theme.EdPostDimensions

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,31 +2,4 @@
     <string name="app_name">SampleApp</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
-    
-    <!-- EPFL Campus Connector -->
-    <string name="error_invalid_url">Invalid URL</string>
-    <string name="error_failed_to_disconnect">Failed to disconnect</string>
-    <string name="error_could_not_open_epfl_campus">Could not open EPFL Campus</string>
-    
-    <!-- Source Labels -->
-    <string name="source_label_epfl_schedule">Your EPFL Schedule</string>
-    <string name="source_label_schedule_description">Retrieved from your connected calendar</string>
-    <string name="source_label_epfl_restaurants">EPFL Restaurants</string>
-    <string name="source_label_food_description">Retrieved from Pocket Campus</string>
-    
-    <!-- ED Post Confirmation Modal -->
-    <string name="ed_post_title_placeholder">Titre</string>
-    <string name="ed_post_body_placeholder">Votre question pour ED…</string>
-    <string name="ed_post_cancel_button">Cancel</string>
-    <string name="ed_post_post_button">Post</string>
-    <string name="select_course">Select a course</string>
-    <string name="post_anonymously">Post anonymously</string>
-    <string name="ed_post_published_title">Posted to Ed</string>
-    <string name="ed_post_published_subtitle">Your question was published.</string>
-    <string name="ed_post_cancelled_title">Post cancelled</string>
-    <string name="ed_post_cancelled_subtitle">Draft was discarded.</string>
-    <string name="ed_post_failed_title">Failed to post on Ed</string>
-    <string name="ed_post_failed_default">Failed to post to Ed</string>
-    <string name="dismiss">Dismiss</string>
-
 </resources>

--- a/app/src/test/java/com/android/sample/home/HomeScreenEdPostResultTest.kt
+++ b/app/src/test/java/com/android/sample/home/HomeScreenEdPostResultTest.kt
@@ -5,8 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.core.app.ApplicationProvider
-import com.android.sample.R
+import com.android.sample.settings.Localization
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -22,39 +21,35 @@ class HomeScreenEdPostResultTest {
 
   @Test
   fun edPostResult_showsFailedBanner() {
-    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
     composeRule.setContent {
       EdPostResult.Failed("Oops").let { result -> EdPostResultBanner(result = result) }
     }
 
-    composeRule.onNodeWithText(ctx.getString(R.string.ed_post_failed_title)).assertIsDisplayed()
+    composeRule.onNodeWithText(Localization.t("ed_post_failed_title")).assertIsDisplayed()
     composeRule.onNodeWithText("Oops").assertIsDisplayed()
   }
 
   @Test
   fun edPostResult_showsCancelledBanner() {
-    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
     composeRule.setContent { EdPostResultBanner(result = EdPostResult.Cancelled) }
 
-    composeRule.onNodeWithText(ctx.getString(R.string.ed_post_cancelled_title)).assertIsDisplayed()
+    composeRule.onNodeWithText(Localization.t("ed_post_cancelled_title")).assertIsDisplayed()
   }
 
   @Test
   fun edPostResult_showsPublishedBanner() {
-    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
     composeRule.setContent { EdPostResultBanner(result = EdPostResult.Published("t", "b")) }
 
-    composeRule.onNodeWithText(ctx.getString(R.string.ed_post_published_title)).assertIsDisplayed()
+    composeRule.onNodeWithText(Localization.t("ed_post_published_title")).assertIsDisplayed()
   }
 
   @Test
   fun edPostResult_dismiss_invokesCallback() {
-    val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
     var dismissed = false
     composeRule.setContent {
       EdPostResultBanner(result = EdPostResult.Cancelled, onDismiss = { dismissed = true })
     }
-    composeRule.onNodeWithContentDescription(ctx.getString(R.string.dismiss)).performClick()
+    composeRule.onNodeWithContentDescription(Localization.t("dismiss")).performClick()
     assertTrue(dismissed)
   }
 }


### PR DESCRIPTION
## What
Moved all user-facing strings from `strings.xml` to `Localization.kt` to centralize text management and align with the current localization approach used in the app.

## How
- Extracted existing string resources from `strings.xml`
- Migrated them into `Localization.kt`
- Updated usages in the codebase to rely on the new localization structure
- Ensured no behavior or UI regressions

## Why
This improves consistency and maintainability of localized content, reduces duplication, and makes future localization and dynamic text handling easier, especially as the app grows and supports more features and flows.
