### PR TITLE
Migration to the new moodlecloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The project design is available on Figma:
 - Firebase Authentication
 - Guest mode support
 - Multi-account support
-- MoodleCloud Authentification (for testing: username:test & password: Eulerpassword1)
+- MoodleCloud Authentification (for testing: username: `test` & password: `Eulerpassword2`)
 - ED Authentification
 
 ---

--- a/app/src/main/java/com/android/sample/settings/connectors/ConnectorScreen.kt
+++ b/app/src/main/java/com/android/sample/settings/connectors/ConnectorScreen.kt
@@ -568,7 +568,7 @@ internal fun MoodleConnectDialog(
     onConfirm: (baseUrl: String, username: String, password: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-  var baseUrl by remember { mutableStateOf("https://euler-swent.moodlecloud.com") }
+  var baseUrl by remember { mutableStateOf("https://euler-04.moodlecloud.com") }
   var username by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }
 

--- a/app/src/test/java/com/android/sample/settings/connectors/ConnectorsViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/settings/connectors/ConnectorsViewModelTest.kt
@@ -384,7 +384,7 @@ class ConnectorsViewModelTest {
         advanceUntilIdle()
 
         viewModel.connectMoodleWithCredentials(
-            baseUrl = "https://euler-swent.moodlecloud.com",
+            baseUrl = "https://euler-04.moodlecloud.com",
             username = "testuser",
             password = "testpass")
         advanceUntilIdle()
@@ -421,7 +421,7 @@ class ConnectorsViewModelTest {
         advanceUntilIdle()
 
         viewModel.connectMoodleWithCredentials(
-            baseUrl = "https://euler-swent.moodlecloud.com",
+            baseUrl = "https://euler-04.moodlecloud.com",
             username = "testuser",
             password = "wrongpass")
         advanceUntilIdle()
@@ -458,7 +458,7 @@ class ConnectorsViewModelTest {
         advanceUntilIdle()
 
         viewModel.connectMoodleWithCredentials(
-            baseUrl = "https://euler-swent.moodlecloud.com",
+            baseUrl = "https://euler-04.moodlecloud.com",
             username = "wronguser",
             password = "wrongpass")
         advanceUntilIdle()
@@ -494,7 +494,7 @@ class ConnectorsViewModelTest {
     viewModel.connectConnector("moodle")
     advanceTimeBy(1000)
     advanceUntilIdle()
-    viewModel.confirmMoodleConnect("https://euler-swent.moodlecloud.com", "test-token")
+    viewModel.confirmMoodleConnect("https://euler-04.moodlecloud.com", "test-token")
     advanceUntilIdle()
 
     val uiState = viewModel.uiState.first()
@@ -529,7 +529,7 @@ class ConnectorsViewModelTest {
     viewModel.connectConnector("moodle")
     advanceTimeBy(1000)
     advanceUntilIdle()
-    viewModel.confirmMoodleConnect("https://euler-swent.moodlecloud.com", "invalid-token")
+    viewModel.confirmMoodleConnect("https://euler-04.moodlecloud.com", "invalid-token")
     advanceUntilIdle()
 
     val uiState = viewModel.uiState.first()


### PR DESCRIPTION
**Description**
Migrates from the expired euler-swent.moodlecloud.com trial to the new euler-04.moodlecloud.com instance and updates test credentials.

**What**
Updated default MoodleCloud URL from euler-swent to euler-04
Updated test credentials in README (password changed to Eulerpassword2)

**Why **
The free MoodleCloud trial for euler-swent expired. Created a new instance euler-04 to continue development and testing.

**How**
Replaced all occurrences of the old URL in ConnectorScreen.kt and test files. Updated README with new test credentials.